### PR TITLE
Add more context to check requests and provide useful iterators

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -25,3 +25,4 @@ jobs:
       - run: cat README.md | ltrs check
       - run: ltrs languages
       - run: ltrs check -t "Some text with a apparent mistake"
+      - run: cargo test --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased](https://github.com/jeertmans/languagetool-rust/compare/v1.0.0...HEAD)
+## [1.1.0](https://github.com/jeertmans/languagetool-rust/compare/v1.0.0...v1.1.0)
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `get_text` method for `CheckRequest`. [#8](https://github.com/jeertmans/languagetool-rust/pull/8)
 - Create `CheckResponseWithContext` that enables keeping information about checked text. Hence, mutable and immutable iterators have been created to provide more tools to the end-user. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
 - Add `--more-context` option flag to CLI. This enables to add more information in the JSON output. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
-- Derive `Eq` for all structs that derive `PartialEq`. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
+- Derive `Eq` for all structs that derive `PartialEq` and with fields that derive `Eq`. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `get_text` method for `CheckRequest`. [#8](https://github.com/jeertmans/languagetool-rust/pull/8)
+- Create `CheckResponseWithContext` that enables keeping information about checked text. Hence, mutable and immutable iterators have been created to provide more tools to the end-user. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
+- Add `--more-context` option flag to CLI. This enables to add more information in the JSON output. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create `CheckResponseWithContext` that enables keeping information about checked text. Hence, mutable and immutable iterators have been created to provide more tools to the end-user. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
 - Add `--more-context` option flag to CLI. This enables to add more information in the JSON output. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
 - Derive `Eq` for all structs that derive `PartialEq` and with fields that derive `Eq`. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
+- Add `from_env` and `from_env_or_default` methods for `ServerCli` and `ServerClient`. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `get_text` method for `CheckRequest`. [#8](https://github.com/jeertmans/languagetool-rust/pull/8)
 - Create `CheckResponseWithContext` that enables keeping information about checked text. Hence, mutable and immutable iterators have been created to provide more tools to the end-user. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
 - Add `--more-context` option flag to CLI. This enables to add more information in the JSON output. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
+- Derive `Eq` for all structs that derive `PartialEq`. [#10](https://github.com/jeertmans/languagetool-rust/pull/10)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "languagetool-rust"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "annotate-snippets",
  "clap 3.2.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +63,12 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -66,6 +84,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
 version = "3.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
@@ -78,7 +107,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
@@ -118,6 +147,115 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "criterion"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+dependencies = [
+ "atty",
+ "cast",
+ "clap 2.34.0",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "once_cell",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "either"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "encoding_rs"
@@ -169,12 +307,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -182,6 +336,34 @@ name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -201,10 +383,16 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -225,6 +413,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -255,7 +449,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.2",
 ]
 
 [[package]]
@@ -296,7 +490,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -355,6 +549,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,7 +583,9 @@ name = "languagetool-rust"
 version = "1.0.0"
 dependencies = [
  "annotate-snippets",
- "clap",
+ "clap 3.2.12",
+ "criterion",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",
@@ -416,6 +627,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +672,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +695,12 @@ name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
@@ -543,6 +778,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "plotters"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9428003b84df1496fb9d6eeee9c5f8145cb41ca375eb0dad204328888832811f"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0918736323d1baff32ee0eade54984f6f201ad7e97d5cfb5d6ab4a358529615"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +848,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +879,27 @@ checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -646,6 +954,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +971,12 @@ dependencies = [
  "lazy_static",
  "windows-sys",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
@@ -688,6 +1011,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,7 +1037,7 @@ version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
- "itoa",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -716,7 +1049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -779,6 +1112,15 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
@@ -801,6 +1143,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -926,6 +1278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +1306,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "^1.0"
 tokio = { version = "^1.0", features = ["macros", "rt-multi-thread"], optional = true }
 
 [dev-dependencies]
-criterion = "0.3" 
+criterion = "0.3"
 futures = "0.3"
 tokio = { version = "^1.0", features = ["macros"]}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,8 @@ name = "ltrs"
 path = "src/bin.rs"
 required-features = ["cli", "tokio"]
 
+[[test]]
+name = "match-positions"
+path = "tests/match_positions.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "languagetool-rust"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Jérome Eertmans <jeertmans@icloud.com>"]
 edition = "2021"
 description = "LanguageTool API bindings in Rust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ thiserror = "^1.0"
 tokio = { version = "^1.0", features = ["macros", "rt-multi-thread"], optional = true }
 
 [dev-dependencies]
+criterion = "0.3" 
+futures = "0.3"
 tokio = { version = "^1.0", features = ["macros"]}
-
 
 [features]
 annotate = ["annotate-snippets"]
@@ -47,5 +48,9 @@ required-features = ["cli", "tokio"]
 [[test]]
 name = "match-positions"
 path = "tests/match_positions.rs"
+
+[[bench]]
+name    = "bench_main"
+harness = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #### Default Features
 
-- **cli**: Adds command-line related methods for multiple structures. This is feature is required to install the LTRS CLI.
+- **cli**: Adds command-line related methods for multiple structures. This feature is required to install the LTRS CLI.
 
 #### Optional Features
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ use languagetool_rust::{check::CheckRequest, server::ServerClient};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = ServerClient::default();
+    let client = ServerClient::from_env_or_default();
 
     let req = CheckRequest::default()
-        .with_text("Some phrase with a smal mistake");
+        .with_text("Some phrase with a smal mistake".to_string());
 
     println!(
         "{}",

--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -1,0 +1,7 @@
+use criterion::criterion_main;
+
+mod benchmarks;
+criterion_main! {
+    benchmarks::check_texts::checks,
+
+}

--- a/benches/benchmarks/check_texts.rs
+++ b/benches/benchmarks/check_texts.rs
@@ -1,0 +1,75 @@
+use criterion::{black_box, criterion_group, Criterion};
+use futures::future::join_all;
+use languagetool_rust::{
+    check::{CheckRequest, CheckResponse, CheckResponseWithContext},
+    error::Error,
+    server::ServerClient,
+};
+
+async fn request_until_success(req: &CheckRequest, client: &ServerClient) -> CheckResponse {
+    loop {
+        match client.check(&req).await {
+            Ok(resp) => return resp,
+            Err(Error::InvalidRequest { body })
+                if body == "Error: Server overloaded, please try again later".to_string() =>
+            {
+                continue
+            }
+            Err(e) => panic!("Some unexpected error occured: {}", e),
+        }
+    }
+}
+
+#[tokio::main]
+async fn check_text_basic(text: &str) -> CheckResponse {
+    let client = ServerClient::from_env().unwrap();
+    let req = CheckRequest::default().with_text(text.to_string());
+    request_until_success(&req, &client).await
+}
+
+#[tokio::main]
+async fn check_text_split(text: &str) -> CheckResponse {
+    let client = ServerClient::from_env().unwrap();
+    let lines = text.lines();
+
+    let resps = join_all(lines.map(|line| async {
+        let req = CheckRequest::default().with_text(line.to_string());
+        let resp = request_until_success(&req, &client).await;
+        CheckResponseWithContext::new(req.get_text(), resp)
+    }))
+    .await;
+
+    resps
+        .into_iter()
+        .reduce(|acc, item| acc.append(item))
+        .unwrap()
+        .into()
+}
+
+#[macro_export]
+macro_rules! compare_checks_on_file {
+    ($name:ident, $filename:expr) => {
+        fn $name(c: &mut Criterion) {
+            let content = std::fs::read_to_string($filename).unwrap();
+            let text = content.as_str();
+            let name = stringify!($name);
+            c.bench_function(format!("Check basic for {}", name).as_str(), |b| {
+                b.iter(|| check_text_basic(black_box(text)))
+            });
+            c.bench_function(format!("Check split for {}", name).as_str(), |b| {
+                b.iter(|| check_text_split(black_box(text)))
+            });
+        }
+    };
+}
+
+compare_checks_on_file!(compare_checks_small_file, "./benches/small.txt");
+compare_checks_on_file!(compare_checks_medium_file, "./benches/medium.txt");
+compare_checks_on_file!(compare_checks_large_file, "./benches/large.txt");
+
+criterion_group!(
+    checks,
+    compare_checks_small_file,
+    compare_checks_medium_file,
+    compare_checks_large_file
+);

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -1,0 +1,1 @@
+pub mod check_texts;

--- a/benches/large.txt
+++ b/benches/large.txt
@@ -1,0 +1,1160 @@
+The Project Gutenberg eBook of Proxy Planeteers, by Edmond Hamilton
+
+This eBook is for the use of anyone anywhere in the United States and
+most other parts of the world at no cost and with almost no restrictions
+whatsoever. You may copy it, give it away or re-use it under the terms
+of the Project Gutenberg License included with this eBook or online at
+www.gutenberg.org. If you are not located in the United States, you
+will have to check the laws of the country where you are located before
+using this eBook.
+
+Title: Proxy Planeteers
+
+Author: Edmond Hamilton
+
+Release Date: August 2, 2022 [eBook #68669]
+
+Language: English
+
+Produced by: Greg Weeks, Mary Meehan and the Online Distributed
+             Proofreading Team at http://www.pgdp.net.
+
+*** START OF THE PROJECT GUTENBERG EBOOK PROXY PLANETEERS ***
+
+
+
+
+
+                           PROXY PLANETEERS
+
+                          By EDMOND HAMILTON
+
+           [Transcriber's Note: This etext was produced from
+                     Startling Stories, July 1947.
+         Extensive research did not uncover any evidence that
+         the U.S. copyright on this publication was renewed.]
+
+
+Doug Norris hesitated for an instant. He knew that another movement
+might well mean disaster.
+
+Here deep in the cavernous interior of airless Mercury, catastrophe
+could strike suddenly. The rocks of the fissure he was following had a
+temperature of hundreds of degrees. And he could hear the deep rumble
+of shifting rock, close by.
+
+But it was not these dangers of the infernal underworld that made him
+hesitate. It was that sixth sense of imminent peril that he had felt
+twice before while exploring the Mercurian depths. Each time, it had
+ended disastrously.
+
+"Just nerves," Norris muttered to himself. "The uranium vein is clearly
+indicated. I've got to follow it."
+
+As he again moved forward and followed that thin, black stratum in the
+fissure wall, his eyes constantly searched ahead.
+
+Then a half-dozen little clouds of glowing gas flowed toward him from a
+branching fissure. Each was several feet in diameter, a faint-glowing
+mass of vapor with a brighter core.
+
+Norris moved hastily to avoid them. But there was a sudden flash of
+light. Then everything went black before his eyes.
+
+"It's happened to me again!" Doug Norris thought in sharp dismay.
+
+Frantically he jiggled his controls, cut in emergency power switches,
+overloaded his tight control beam to the limit. It was no use. He still
+could not see or hear anything whatever.
+
+Norris defeatedly took the heavy television helmet with its bulging
+eyepieces off his head. He stared at the control-board, then looked
+blankly out the window at the distant, sunlit stacks of New York Power
+Station.
+
+"Another Proxy gone! Seven of them wrecked in the last two weeks!"
+
+It hadn't just happened, of course. It had happened eight minutes ago.
+It took that long for the television beam from the Proxy to shuttle
+from Mercury to this control-station outside New York. And it took as
+long again for the Proxy control-beam to get back to it on Mercury.
+
+Sometimes, a time-lag that long could get a Proxy into trouble before
+its operator on Earth was aware of it. But usually that was not a big
+factor of danger on a lifeless world like Mercury. The Proxies, built
+of the toughest refractory metals, could stand nearly anything but an
+earthquake, and keep on functioning.
+
+"Each time, there's been no sign of falling rocks or anything like
+that," Norris told himself, mystified. "Each time, the Proxy has just
+blacked out with all its controls shot."
+
+       *       *       *       *       *
+
+Then, as his mind searched for some factor common to all the disasters,
+a startled look came over Doug Norris' lean, earnest face.
+
+"There _were_ always some of those clouds of radon or whatever they
+are around, each time!" he thought. "I wonder if--" A red-hot thought
+brought him to his feet. "Holy cats! Maybe I've got the answer!"
+
+He jumped away from the Proxy-board without a further glance at that
+bank of intricate controls, and hurried down a corridor.
+
+Through the glass doors he passed, Norris could see the other operators
+at work. Each sat in front of his control-board, wearing his television
+helmet, flipping the switches with expert precision. Each was operating
+a mechanical Proxy somewhere on Mercury.
+
+Norris and all these other operators had been trained together when
+Kincaid started the Proxy Project. They had been proud of their
+positions, until recently. It _was_ a vitally important job, searching
+out the uranium so sorely needed for Earth's atomic power supply.
+
+The uranium and allied metals of Earth had years ago been ransacked
+and used up. There was little on Venus or Mars. Mercury had much of
+the precious metal in its cavernous interior. But no man, no matter
+how ingenious his protection, could live long enough on the terrible,
+semi-molten Hot Side of Mercury to conduct mining operations.
+
+That was why Kincaid had invented the Proxies. They were machines
+that could mine uranium where men couldn't go. Crewless ships guided
+by radar took the Proxies to the Base on Mercury's sunward side. From
+Base, each Proxy was guided by an Earth operator down into the hot
+fissures to find and mine the vital radioactive element. The scheme had
+worked well, until--
+
+"Until we got into those deeper fissures with the Proxies," Doug Norris
+thought. "Seven wrecked since then! This _must_ be the answer!"
+
+Martin Kincaid looked up sharply as Norris entered his office. A look
+of faint dismay came on Kincaid's square, patient face. He knew that
+a Proxy operator wouldn't leave his board in the middle of a shift,
+unless there was trouble.
+
+"Go ahead and give me the bad news, Doug," he said wearily.
+
+"Proxy M-Fifty just blacked out on me, down in Fissure Four," Norris
+admitted. "Just like the others. But I think I know why, now!" He
+continued excitedly: "Mart, seven Proxies blacking out in two weeks
+wasn't just accident. It was done deliberately!"
+
+Kincaid stared. "You mean that Hurriman's bunch is somehow sabotaging
+our Project?"
+
+Doug Norris interrupted with a denial. "Not that. Hurriman and his
+fellow politicians merely want to get their hands on the Proxy Project,
+not to destroy it."
+
+"Then who did wreck our Proxies?" Kincaid demanded.
+
+Norris answered excitedly. "I believe we've run into living creatures
+in those depths, and they're attacking us."
+
+Kincaid grunted. "The temperature in those fissures is about four
+hundred degrees Centigrade, the same as Mercury's sunward side. Life
+can't exist in heat like that. I suggest you take a rest."
+
+"I know all that," Norris said impatiently. "But suppose we've run into
+a new kind of life there--one based on radioactive matter? Biologists
+have speculated on it more than once. Theoretically, creatures of
+radioactive matter could exist, drawing their energies not from
+chemical metabolism as we do, but from the continuous process of
+radioactive disintegration."
+
+"Theoretically, the sky is a big roof with holes in it that are stars,"
+growled Kincaid. "It depends on whose theory you believe."
+
+"Every time a Proxy has blacked out down there, there's been little
+clouds of heavy radioactive gas near," argued Doug Norris. "Each seems
+to have a denser core. Suppose that core is an unknown radium compound,
+evolved into some kind of neuronic structure that is able to receive
+and remember stimuli? A sort of queer, radioactive brain?
+
+"If that's so, and biologists have said it's possible, the _body_ of
+the creature consists of radon gas emanated from the radium core. You
+remember the half-life of radon exactly equals the rate of its emission
+from radium, so there'd be a constant equilibrium of the thing's
+gaseous body, analogous to our blood circulation. Given Mercury's
+conditions, it's no more impossible than a jellyfish or a man here on
+Earth!"
+
+       *       *       *       *       *
+
+Kincaid looked skeptical.
+
+"And you think these hypothetical living Raddies of yours are attacking
+our Proxies? Why would they?"
+
+"If they have cognition and correlation faculties they might be
+irritated by the tube emanations from the control-boxes of our
+Proxies," Norris suggested. "They get into those control-boxes and
+wreck the tube circuits by overloading the electron flow with their own
+Beta radiation!"
+
+"It's all pretty far-fetched," muttered his superior. "Radioactive
+life! But all those Proxies blowing can't be just chance." He paused,
+then added gloomily, "But I can just see myself telling a World Council
+committee that your hypothetical living Raddies are what keep us from
+delivering uranium! Hurriman would like that. It would convince the
+Council that I'm as incompetent as he claims."
+
+"He'll convince the Council of that anyway unless we deliver uranium
+from Mercury quickly," retorted Norris. "And we'll never do it till
+we get these Raddies licked. They're basically just complex clouds of
+radioactive gas. A Proxy armed with a high-pressure gas hose should be
+able to blow them to rags. Can't we try it, Mart?"
+
+Kincaid sighed, and stood up.
+
+"I was a practical man once," he said wearily, "and would have booted
+you out of here if you'd suggested such stuff. But I'm a drowning man
+right now, so I'll buy your straw. We'll send down a couple of Proxies
+armed with gas hoses and see how they make out."
+
+Doug Norris eagerly went with his superior into the adjoining room
+where the operators of the Base Proxies were on duty.
+
+"Norris and I will take over two Proxies at base," Kincaid told the
+sub-chief there.
+
+Two operators took off their helmets and got out of their chairs.
+Norris took the place of one, donning the television helmet.
+
+The control and television beams were on. The compact kinescope tubes
+in his helmet gave him a clear vision of the Base on Mercury, as seen
+through his Proxy's iconoscope "eyes".
+
+There were no buildings, for Proxies didn't need shelter. The seared
+black rocks stretched under a brazen sky, beneath a stupendous Sun
+whose blaze even the iconoscope filters couldn't cut down much. The
+Base was just a flat area here beside the low rock hills. A crewless
+ship lay to one side, its hatches open. Near it were the supply-dumps
+of Proxy parts, the repair shops, the power plant.
+
+"We'll get a couple of oxygen tanks from the supply dump and use them
+for your gas hose weapons," Kincaid was saying.
+
+The Proxies they were guiding did not look like men. They looked like
+what they were--machines devised for special purposes. They were like
+baby tanks, mounted on caterpillar drives, each with two big jointed
+arms ending in claws, and a control-box with iconoscope eyes. They
+clamped on the high-pressure oxygen tanks, clutched the nozzles of the
+attached hoses, and rolled out of Base across the seared plain toward
+the black rock hills. In a few minutes, they entered the narrow cleft
+of Fissure Four.
+
+Norris knew the way down here. He led, switching on his searchlight
+even though he didn't really need it. The Proxy's iconoscope eyes could
+see by the infra-red radiation from the superheated rock walls.
+
+They finally reached the spot deep down in the fissure where his
+disabled former Proxy still stood. Doug Norris reached his jointed arms
+and quickly unclamped the shield of its control-box.
+
+"Look there, Mart! The whole control's shot! They do it by overloading
+the tubes with their own Beta emanations, all right."
+
+Kincaid's Proxy had elbowed close, its big iconoscope eyes peering
+closely. Here in the office, Kincaid uttered a grunt.
+
+"That still doesn't prove the gas that did it was living. Instead of
+your hypothetical Raddies, it could be--"
+
+"Look there!" yelled Doug Norris suddenly. "There they come again!"
+
+Three of the glowing gaseous things were flowing toward them along the
+fissure. They poised for a moment in a lifelike way, and then swept
+forward.
+
+"Your gas hose!" yelled Norris to the man beside him. "Don't let them
+get near you!"
+
+The Raddies were advancing in a deliberate way. In spite of the
+time-lag, Norris tried to raise his gas hose and trigger it. There
+wasn't time. The eight-minute lag between his action and the result out
+there on Mercury was fatally long. The glowing Raddies were flowing up
+around the Proxies.
+
+Doug Norris was momentarily dazzled by the brilliance of the Raddy that
+enveloped his Proxy's control-box. It was like looking into a star to
+look into the glowing, pulsing core of the thing.
+
+His senses reeled queerly as he stared, hypnotized by the swirling
+bright gas and the starlike, throbbing core. He sensed dimly that
+that core was a kind of life possible on no terrestrial planet,
+a crystalized gaseous neurone structure that used its own radon
+emanations as a body.
+
+       *       *       *       *       *
+
+He felt his senses staggering, darkening. It was as though he were
+hypnotized by the brilliance of that pulsing core of light, as though
+it were probing excruciatingly into his brain.
+
+Then Doug Norris came out of his queer daze to find himself sitting
+there with his helmet dead. He could see nothing. His movements of the
+Proxy controls yielded no response.
+
+"Blacked out, both our Proxies!" Kincaid exclaimed, dazedly taking off
+his own helmet. "And we got some kind of kick-back shock."
+
+Norris, still badly shaken, nodded unsteadily. "There must have been a
+kick-back along the control beam when they blew the control-boxes. The
+circuit breakers may have been slow." He added quickly, "But you know
+now I was right! Those Raddies are living things, that instinctively
+attack our Proxies!"
+
+Kincaid frowned. "It looks like it. But no gas hose or any other
+weapon will work against the brutes. The time-lag makes it impossible
+to use weapons. Our only chance is to seal and ray-proof the Proxies'
+control-boxes against them. That'll take time. But it's our only chance
+to get uranium out of there, and it's got to be done before Hurriman's
+clique gets the Council on our tail. I'll have the boys bring the
+Proxies all back to Base at once."
+
+Norris followed his chief back to his office. Winters, the office
+clerk, was waiting there for them, and looking anxious.
+
+"A bulletin just came over the news tape, Chief," he told Kincaid.
+"Here it is."
+
+Mart Kincaid read the tape, and his square shoulders seemed to sag a
+little. He looked at them heavily.
+
+"We won't need to worry any more about your Raddies, Doug. World
+Council has just passed Hurriman's motion requesting an immediate
+investigation of Proxy Project. It will begin tomorrow." He added
+tonelessly, "You know what that means. When they find we've lost nine
+valuable Proxies out there on Mercury without getting any uranium at
+all yet, we'll be thrown out."
+
+"Blast Hurriman!" Doug Norris raged. "The Proxy Project has been your
+work from the start! You sweated to develop the things. Now because
+there's a hitch, a bunch of bumbling politicians take it over!"
+
+"It's all in a lifetime," Kincaid shrugged. "Winters, you tell the
+boys. Have them pull their Proxies back to Base, and go home." He sat
+down slowly in his chair then, and stared at the wall. "So it's over.
+Well, right now I'm too tired to care."
+
+Norris felt heartsick. "Isn't there any chance of stalling them long
+enough to try our idea of rayproofing the Proxies?"
+
+"You know there isn't," said his superior. "It'd take days to do that
+job. Even if it worked against the Raddies, it'd take weeks more to
+get out uranium. And Hurriman's bunch won't wait weeks."
+
+He looked at the sick face of the younger man, then opened a desk
+drawer and took out a bottle of Scotch and glasses.
+
+"Here, have a drink," he ordered. "You're a little young yet, and you
+take these things too seriously."
+
+Norris unhappily drank the Scotch. But his nerves, still shaken by that
+queer kick-back shock from the beam, didn't relax much.
+
+"Mart, your calmness isn't fooling me," he said. "I know how much the
+Proxies meant to you, the dreams you had of operating Proxies on every
+planet man couldn't visit, even on worlds of distant stars."
+
+Kincaid shrugged as he poured himself a drink. "Sure, I wanted
+all that. But since when have scientists ever been able to buck
+politicians?"
+
+Darkness pressed the windows as night gathered. They sat silently in
+the darkening office drinking the Scotch and looking at the tall,
+lighted stacks of the distant New York Power Station.
+
+Doug Norris found no comfort in the liquor's sting. His sense of
+injustice deepened. The Proxies were Kincaid's, but just because he
+couldn't produce uranium fast enough, they would be taken away from him.
+
+He said so, bitterly and at length. Kincaid only shrugged wearily again.
+
+"Forget it, Doug. Have another drink."
+
+Norris discovered with mild surprise that the bottle was empty.
+
+"We must have spilled some of it," he said a little thickly.
+
+"There's another bottle in the drawer," Kincaid grunted. "They were for
+the Project party next week, but that's all off now."
+
+       *       *       *       *       *
+
+Norris opened the other bottle and generously refilled their glasses.
+He sat down beside Kincaid, who was looking broodingly from the window
+at the distant atomic power plant. Despite the warm physical glow he
+felt, Doug Norris was unhappier than before. A new, poignant sorrow had
+risen in him.
+
+"You know, Mart, it isn't only what Hurriman's doing to the Project
+that's got me down," he said sorrowfully. "It's what happened to old
+M-Fifty today."
+
+"M-Fifty?" Kincaid inquired. "You mean that Proxy you lost this
+afternoon?"
+
+"Yes, he was my special Proxy for all these months," Doug Norris said.
+"I got to know him. He was always dependable, never jumped his control
+beam, never acted cranky in a tight place." His voice choked a little.
+"I loved that Proxy like a brother. And I let him down. I let those
+Raddies wreck him."
+
+"They'll fix him up, Doug," said Kincaid, a rich sympathy in his
+slightly thickened voice. "They'll make him as good as new when they
+get him back up to Base."
+
+"Yes, but what good will that do if I'm not here to operate him?" cried
+Norris. "I tell you, that Proxy was sensitive. He knew my touch on the
+controls. That Proxy would have died for me."
+
+"Sure he would." Kincaid nodded with owlish understanding. "Here, have
+another drink, Doug."
+
+"I've had enough," Norris said gloomily, refilling their glasses as
+he spoke. "But as I was saying, that Proxy won't run for a bunch of
+politicians and their ham-handed operators like he ran for me. He'll
+know that I'm gone, and he won't be the same. He'll pine."
+
+"That's the way it goes, Doug," Kincaid said sadly. "You lose your best
+friend--I mean, your best Proxy--and I lose my Project, just because we
+can't furnish enough uranium for power over there."
+
+He gestured bitterly toward the distant stacks of New York Power
+Station that soared like towers of light in the distant darkness.
+
+"You know, I've got an idea in my mind about that," Kincaid added
+slowly, as he stared at those towers.
+
+Doug Norris nodded emphatically. "You're dead right, Mart. You're
+absolutely right."
+
+"Now wait, you didn't hear my idea yet," Kincaid protested a little
+foggily. "It's this--we're losing the Project because we can't furnish
+enough uranium for power. But suppose they didn't need uranium for
+power any longer? Then they'd let us keep the Proxy Project!"
+
+"Exactly what _I_ say!" Norris declared firmly. "There's just one thing
+for us to do. That's to find a way to produce atomic power from some
+commoner substance than uranium. That'd solve our whole problem."
+
+"I thought I was the one who said that," Kincaid said, puzzled. "But
+look--what fairly common metal could be used to replace uranium in the
+atomic piles?"
+
+"Bismuth, of course," Norris replied promptly. "Its atomic number is
+closest to the radioactive series of elements."
+
+"You took the words right out of my mouth!" Kincaid declared. "Bismuth
+it is. All we have to do is to make bismuth work in an atomic pile,
+then we can run the Proxy Project without this everlasting nagging
+about supplying uranium."
+
+Doug Norris felt a warm, happy relief. "Why, it's simple! We should
+have thought of it before! Let's get some bismuth out of the supply
+room and go over to the Power Station right now!" He leaped to his
+feet, eagerly, if a trifle unsteadily. "No time to waste, if the
+Council committee's to be on our necks tomorrow!"
+
+Doug Norris felt like singing in his wonderful relief, as he and
+Kincaid went down through the now deserted Project building to the
+supply room. In fact, he started to raise his voice in a ribald ballad
+about a Proxy's adventure with a lady automaton.
+
+"You mus' have had a trifle too much Scotch, Doug," Kincaid reproved
+him, with owlish dignity. "Such levity isn't becoming to two scientists
+about to make the mos' wonderful invention of the century."
+
+They got one of the heavy leaden cylinders used for transport of
+uranium and filled it carefully with powdered bismuth. Then, in
+Kincaid's car, they drove happily toward the big Power Station.
+
+The guards at the barrier gate knew them both, for it was nothing new
+for Proxy Project men to bring uranium over to the Station. They let
+them through, and the car eased along the straight cement road.
+
+The huge, windowless buildings that housed the massive uranium piles
+were a mile beyond. But no one went near those tremendous atomic piles.
+Everything in them had to be handled by remote control by the few
+technicians in Headquarters Building who kept them operating.
+
+"Mart, isn't it queer nobody ever thought of usin' bismuth instead of
+uranium, before now?" Norris asked, out of his roseate glow.
+
+"Scientists too c'nservative, that's the trouble," Kincaid answered
+wisely. His voice soared. "We're about to launch a new epoch! No more
+uranium shortage to worry 'bout! No more politicians botherin' the
+Project!"
+
+"And I'll be able to fix up old M-Fifty and run him myself again,"
+added Doug Norris. He choked up once more. "When I think of that Proxy
+that was like a brother to me, lyin' down in that lonely fissure with
+the Raddies gloatin' over him--"
+
+"Don't think about it, Doug," begged Kincaid, with tender sympathy.
+"Soon's we get these atomic piles changed around, we'll go back and get
+good old M-Fifty up again and fix him good as new."
+
+       *       *       *       *       *
+
+That promise cheered Norris' grieving mind. He got out and helped
+Kincaid carry the heavy lead cylinder into Headquarters Building.
+
+The technicians they passed in the lower rooms saw nothing surprising
+in the two Project men staggering along under the weight of the
+cylinder. Nor did Petersen and Thorpe, at first.
+
+Petersen and Thorpe were the two technicians on duty in the big, sacred
+inmost chamber of controls. Visors here gave view of every part of the
+distant, mighty atomic piles--the massive lead towers that enclosed
+the graphite and uranium lattices, the gas penstocks that led to giant
+heat turbines, the gauges and meters. And the banks of heavy levers
+here could switch those lattices, make any desired change in the piles,
+without the necessity of a man entering the zone of dangerous radiation.
+
+Petersen had surprise on his spectacled, scholarly face as he greeted
+the two scientists.
+
+"I didn't know you had another uranium consignment for us," he said.
+
+Kincaid helped Norris place the lead cylinder in the breech of the tube
+that would carry it mechanically to the distant pile.
+
+"This isn't uranium--it's better than uranium," Kincaid announced
+impressively.
+
+"What do you mean, better than uranium?" Petersen asked in a puzzled
+tone. He opened the end of the lead cylinder. "Why, this stuff is
+bismuth! What is this, a crazy joke?"
+
+Young Thorpe had been staring closely at Kincaid and Norris.
+
+"They're both plastered!" he burst out.
+
+Kincaid drew himself up in an unsteady attitude of outraged dignity.
+
+"Tha's what thanks we get," he accused thickly. "We come here to make
+a won'erful improvement in your blasted old atomic piles, and we get
+insulted."
+
+"Thorpe," Petersen said disgustedly, "get them out of here, and ...
+_Look out!_"
+
+Doug Norris had casually taken the heavy metal handle off one of the
+big levers. He tapped Thorpe on the head with it just as Petersen
+uttered his warning cry. The young technician slumped.
+
+Petersen, suddenly pale, darted toward an alarm button on his desk. But
+before he reached it, Norris' improvised blackjack tapped his skull.
+And Petersen also sagged to the floor.
+
+[Illustration: Before Petersen could reach the alarm button, the
+blackjack hit him.]
+
+Norris looked triumphantly at Kincaid, with a warm feeling of righteous
+virtue.
+
+"They won't bother us now, Mart. I just put them out for a little while
+without hurting 'em."
+
+"Quick thinking, Doug!" Kincaid approved warmly. "Can't let
+reactionaries obstruc' course of scientific progress. We'd better tie
+'em up in case they come around too soon."
+
+Norris helped tie the two unconscious men with lengths of spare cable.
+Then he and Kincaid stood swaying a little as they owlishly inspected
+the controls of the mighty atomic piles.
+
+Norris knew a good bit about those controls. He had been here many
+times, and Petersen and the other technicians had liked to talk. The
+trouble was, that right now his thoughts all seemed a little foggy.
+
+"What we got to do," Kincaid said ponderously, "is change 'round the
+atomic pile setup so it'll handle bismuth instead of uranium. Right?"
+
+"Right!" Norris approved enthusiastically. "That's going right to the
+heart of the problem, old pal!"
+
+Kincaid seemed to blush in deprecation. "Oh, I jus' got an orderly
+mind. First thing now, is to shift the uranium lattices out of the
+piles."
+
+He laid his hands on several of the levers, one after another. There
+was a low humming of machinery somewhere.
+
+In the distant, towering structure, lattices loaded with uranium were
+being mechanically withdrawn to the pits beneath. But there was nothing
+happening here except on the panel of indicators.
+
+Petersen came back to consciousness at that moment. Tied to a wall
+stanchion, he stiffened and his eyes bugged at them.
+
+"What are you two doing?" he cried. "You're cutting off the power by
+pulling out those lattices!"
+
+"Only temp'rarily," Norris assured him. "We'll shift empty lattices
+back in, and then load the bismuth into them."
+
+Petersen uttered a howl of agony. "You maniacs will wreck the whole
+pile if you try a stunt like that! For heaven's sake, sober up and
+think what you're doing!"
+
+"We're tryin' to think," Kincaid said sternly. "But how can we
+co'centrate, with you yelling at us?"
+
+Petersen went from raging orders to agonized pleadings to tearful
+entreaty. The two ignored him completely.
+
+"Le's see, now," Kincaid said, blinking. "We'll leave in the Number
+One uranium lattice after all. We'll need its neutrons to trigger the
+expanding series of graphite and bismuth lattices."
+
+"We'll need _two_ uranium lattices," Doug Norris corrected thickly.
+"One to trigger the first action, the other to pr'vide neutrons for
+the continuous shuttle that'll run the bismuth's atomic number up from
+eighty-three to ninety-four, right up through neptunium to plutonium."
+
+"You're right," Kincaid agreed, hiccuping slightly. "I forgot 'bout
+that second lattice for a minute. Mus' be because of all the noise in
+here."
+
+       *       *       *       *       *
+
+Petersen was still producing that noise, indeed. He had become louder
+and more frantic as he saw them shifting out the uranium lattices and
+replacing them clumsily with empty lattice-frames.
+
+"Ten thousand scientists have been working ever since
+Nineteen-forty-five to find a way to use common elements instead of
+uranium in a pile!" he choked. "They can't do it. But two drunken Proxy
+men are going to try it!"
+
+Norris hardly heard that stream of agonized accusation and entreaty, as
+he helped Kincaid shift in the empty lattices. He was mildly sorry that
+Petersen felt so disturbed. There was no reason for it. He and Kincaid
+knew just what they were doing.
+
+Or did they? For a moment, a dim doubt crossed Norris' foggy mind.
+After all, he and Kincaid weren't physicists. Then he dismissed that
+doubt. He was _sure_ of what they were doing, wasn't he?
+
+Kincaid sat down unsteadily when they had the lattices changed.
+
+"I feel a li'l shaky. 'S emotional reaction from great scientific
+achievement."
+
+"Emotional reaction nothing--you're so plastered you're nearly out!"
+raged Petersen.
+
+Kincaid dignifiedly ignored that. "Switch on the loader and shoot the
+ol' bismuth in there, Doug."
+
+"Norris, _don't_ do it!" begged Petersen hoarsely. "It means wrecking
+the pile, and maybe blowing up the whole Station!"
+
+Again, Doug Norris' dim doubt bothered him. But then again he dismissed
+it. Everything was so beautifully clear in his mind. It had to work.
+
+He switched on the loader. The lead cylinder of bismuth slid away
+into the tube that would carry it to the pile, where it would be
+automatically loaded into the new empty lattices.
+
+"You fools!" choked Petersen. "I hope they hang you both for this! When
+that pile starts up, and blows--"
+
+The operation of the great atomic pile was automatic from this point
+on. Minutes later, a bell rang and indicators clicked on.
+
+"First uranium lattice has triggered off," said Kincaid, and nodded,
+pleased. "Now we'll get power--lotsa power."
+
+"You'll get nothing but maybe an atomic explosion, in ten seconds!"
+cried Petersen, his face deathly white.
+
+Doug Norris suddenly felt his doubt rise again and this time it
+overwhelmed him! All his former foggy confidence seemed to have left
+him as they completed their operations.
+
+He was suddenly aware of the mad and ghastly thing that he and Kincaid
+had done. Why in heaven's name had they done it? What crazy quirk in
+their minds had made them do it?
+
+Kincaid too was suddenly looking pale and queer.
+
+"Doug, maybe we shouldn't have tried it."
+
+"Look at those meters!" yelled Petersen, in a wild voice.
+
+The technician's eyes were protruding as he stared at the big bank of
+ammeters that registered the output of the great turbines. The needles
+were jumping across the dials with swiftly increasing amperage.
+
+"The pile is _working_!" yelled Petersen hoarsely. "That bismuth is
+actually producing atomic power!"
+
+Doug Norris suddenly felt cold sober, and a little sick. He sat down
+shakily, and put his head in his hands.
+
+Kincaid was staring blankly at the ammeters, while Petersen and Thorpe
+seemed to have gone crazy with excitement. When Petersen was untied,
+he grabbed Kincaid fiercely.
+
+"How did you do it?" he cried. "Just what did you do to the pile?"
+
+Kincaid stared at him blankly. "I don't know, now."
+
+"You don't know?" Petersen almost screeched. "Man, you've stumbled on
+what the scientists have been hunting all these years--the hookup to
+use common elements in an atomic pile! You must have had something
+figured out beforehand!"
+
+"We didn't!" Norris denied weakly. "We got a little plastered, and got
+this idea. We didn't know what we were doing."
+
+Suddenly, Doug Norris stiffened. Remembrance that brought him jumping
+unsteadily to his feet had come to him.
+
+"You couldn't have done a thing like this by sheer crazy accident!"
+Petersen was insisting. "You must have known how!"
+
+"By heaven, I believe now that we _did_ know what we were doing, in a
+queer sort of way!" Norris exclaimed shakily. He grabbed Kincaid's arm.
+"Mart, come with me! We're going back over to the Project!"
+
+Petersen's dazed amazement was changing to exultation.
+
+"Whatever you did, it's still working and looks like it'll work
+indefinitely! And we can study the hookup and learn how to duplicate
+it, even if we never completely understand it. You two maniacs are
+going to be famous!"
+
+But Norris had already led the stupefied Kincaid out of the room.
+
+       *       *       *       *       *
+
+All the way back to the Proxy Project, Kincaid kept dazedly repeating
+the same thing over and over.
+
+"We must have been clear out of our heads to do a thing like that! But
+how is it that we were able to do it _right_?"
+
+"Haven't you suspected the answer to that yet?" cried Doug Norris.
+"Don't you see why, as soon as our conscious minds were relaxed by a
+few drinks, we automatically went and performed an operation totally
+beyond present-day nuclear science? What happened to us just before we
+had those drinks? What happened when our Proxies met those Raddies
+down in the fissure?"
+
+"The Raddies?" Kincaid repeated stupidly. "What could those brutes have
+to do with this?"
+
+"We thought they were only brutes, a low form of queer radioactive
+life," Norris said. "But what if their weird minds are intelligent,
+supremely intelligent? An intelligence that doesn't operate for
+purposes or in ways like ours, but that's as high or higher than ours?"
+
+He almost dragged the stunned Kincaid into the deserted office, to the
+control-boards of the Proxies at Base.
+
+"Take over a Proxy and follow me," Norris ordered. "I've an idea that
+if we go down in that fissure again, we can prove it."
+
+"Prove what?" Kincaid asked, but mechanically obeyed and took over a
+Proxy control.
+
+Again, Norris and Kincaid guided their Proxies out of Base and across
+the seared Mercury plain toward Fissure Four. Norris peered down into
+the fissure as he advanced. Then as they glimpsed the wrecked Proxies
+they had previously left there, they also glimpsed glowing little
+clouds flowing rapidly toward them.
+
+A Raddy lifted its glowing gaseous body to envelop the control-box of
+Norris' Proxy. Again, as he stared into the thing's brilliant, pulsing
+core, he felt his senses reel queerly. But this time, he knew beyond
+any doubt what it was.
+
+"Hypnosis!" he yelled to Kincaid. "Hypnosis operating through our
+Proxies' eyes right back along the beam to our own eyes and brains!
+I thought so!" His shout died away as his brain reeled under the
+powerful hypnotic influence of the Raddy's pulsing, starlike core.
+
+Hypnosis could operate by vision, everyone knew that. Nobody had
+dreamed of hypnosis operating across space by means of a linking
+television beam, but it was happening. For Doug Norris, resisting now
+with new-found knowledge, just dimly sensed the powerful hypnotic order
+the Raddy's pulsing brain was hurling into his own mind.
+
+"You will not send your crude machines down here again to disturb our
+philosophical reveries!" the Raddy's hypnotic thought was sternly
+ordering him. "There is no further need. When we read from your minds
+that it was need for uranium for your primitive power plants that
+motivated your intrusions here, we gave your brains the post-hypnotic
+knowledge to improve those power plants so you would not need to come
+here again. So go, and do not return!"
+
+Under that powerful hypnotic command, both Norris and Kincaid turned
+their Proxies and fled back up the fissure.
+
+Not until they had reached Base again, not until they had ripped off
+the television helmets, did Doug Norris feel that powerful hypnotic
+command relax.
+
+"It's as I suspected!" he cried. "It was the Raddies who put that
+knowledge in our minds! Who would know nuclear science better than
+they?"
+
+Kincaid stared, his jaw dropping. "Then, to stop our bothering them,
+they did that by post-hypnotic command working back along our own
+Proxy-beams?"
+
+"Yes!" cried Doug Norris. "Ironic, isn't it? They worked back along our
+own beams and made Proxies out of _us_!"
+
+*** END OF THE PROJECT GUTENBERG EBOOK PROXY PLANETEERS ***
+
+Updated editions will replace the previous one--the old editions will
+be renamed.
+
+Creating the works from print editions not protected by U.S. copyright
+law means that no one owns a United States copyright in these works,
+so the Foundation (and you!) can copy and distribute it in the
+United States without permission and without paying copyright
+royalties. Special rules, set forth in the General Terms of Use part
+of this license, apply to copying and distributing Project
+Gutenberg-tm electronic works to protect the PROJECT GUTENBERG-tm
+concept and trademark. Project Gutenberg is a registered trademark,
+and may not be used if you charge for an eBook, except by following
+the terms of the trademark license, including paying royalties for use
+of the Project Gutenberg trademark. If you do not charge anything for
+copies of this eBook, complying with the trademark license is very
+easy. You may use this eBook for nearly any purpose such as creation
+of derivative works, reports, performances and research. Project
+Gutenberg eBooks may be modified and printed and given away--you may
+do practically ANYTHING in the United States with eBooks not protected
+by U.S. copyright law. Redistribution is subject to the trademark
+license, especially commercial redistribution.
+
+START: FULL LICENSE
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full
+Project Gutenberg-tm License available with this file or online at
+www.gutenberg.org/license.
+
+Section 1. General Terms of Use and Redistributing Project
+Gutenberg-tm electronic works
+
+1.A. By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or
+destroy all copies of Project Gutenberg-tm electronic works in your
+possession. If you paid a fee for obtaining a copy of or access to a
+Project Gutenberg-tm electronic work and you do not agree to be bound
+by the terms of this agreement, you may obtain a refund from the
+person or entity to whom you paid the fee as set forth in paragraph
+1.E.8.
+
+1.B. "Project Gutenberg" is a registered trademark. It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement. There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement. See
+paragraph 1.C below. There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this
+agreement and help preserve free future access to Project Gutenberg-tm
+electronic works. See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation ("the
+Foundation" or PGLAF), owns a compilation copyright in the collection
+of Project Gutenberg-tm electronic works. Nearly all the individual
+works in the collection are in the public domain in the United
+States. If an individual work is unprotected by copyright law in the
+United States and you are located in the United States, we do not
+claim a right to prevent you from copying, distributing, performing,
+displaying or creating derivative works based on the work as long as
+all references to Project Gutenberg are removed. Of course, we hope
+that you will support the Project Gutenberg-tm mission of promoting
+free access to electronic works by freely sharing Project Gutenberg-tm
+works in compliance with the terms of this agreement for keeping the
+Project Gutenberg-tm name associated with the work. You can easily
+comply with the terms of this agreement by keeping this work in the
+same format with its attached full Project Gutenberg-tm License when
+you share it without charge with others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are
+in a constant state of change. If you are outside the United States,
+check the laws of your country in addition to the terms of this
+agreement before downloading, copying, displaying, performing,
+distributing or creating derivative works based on this work or any
+other Project Gutenberg-tm work. The Foundation makes no
+representations concerning the copyright status of any work in any
+country other than the United States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other
+immediate access to, the full Project Gutenberg-tm License must appear
+prominently whenever any copy of a Project Gutenberg-tm work (any work
+on which the phrase "Project Gutenberg" appears, or with which the
+phrase "Project Gutenberg" is associated) is accessed, displayed,
+performed, viewed, copied or distributed:
+
+  This eBook is for the use of anyone anywhere in the United States and
+  most other parts of the world at no cost and with almost no
+  restrictions whatsoever. You may copy it, give it away or re-use it
+  under the terms of the Project Gutenberg License included with this
+  eBook or online at www.gutenberg.org. If you are not located in the
+  United States, you will have to check the laws of the country where
+  you are located before using this eBook.
+
+1.E.2. If an individual Project Gutenberg-tm electronic work is
+derived from texts not protected by U.S. copyright law (does not
+contain a notice indicating that it is posted with permission of the
+copyright holder), the work can be copied and distributed to anyone in
+the United States without paying any fees or charges. If you are
+redistributing or providing access to a work with the phrase "Project
+Gutenberg" associated with or appearing on the work, you must comply
+either with the requirements of paragraphs 1.E.1 through 1.E.7 or
+obtain permission for the use of the work and the Project Gutenberg-tm
+trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any
+additional terms imposed by the copyright holder. Additional terms
+will be linked to the Project Gutenberg-tm License for all works
+posted with the permission of the copyright holder found at the
+beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including
+any word processing or hypertext form. However, if you provide access
+to or distribute copies of a Project Gutenberg-tm work in a format
+other than "Plain Vanilla ASCII" or other format used in the official
+version posted on the official Project Gutenberg-tm website
+(www.gutenberg.org), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original "Plain
+Vanilla ASCII" or other form. Any alternate format must include the
+full Project Gutenberg-tm License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works
+provided that:
+
+* You pay a royalty fee of 20% of the gross profits you derive from
+  the use of Project Gutenberg-tm works calculated using the method
+  you already use to calculate your applicable taxes. The fee is owed
+  to the owner of the Project Gutenberg-tm trademark, but he has
+  agreed to donate royalties under this paragraph to the Project
+  Gutenberg Literary Archive Foundation. Royalty payments must be paid
+  within 60 days following each date on which you prepare (or are
+  legally required to prepare) your periodic tax returns. Royalty
+  payments should be clearly marked as such and sent to the Project
+  Gutenberg Literary Archive Foundation at the address specified in
+  Section 4, "Information about donations to the Project Gutenberg
+  Literary Archive Foundation."
+
+* You provide a full refund of any money paid by a user who notifies
+  you in writing (or by e-mail) within 30 days of receipt that s/he
+  does not agree to the terms of the full Project Gutenberg-tm
+  License. You must require such a user to return or destroy all
+  copies of the works possessed in a physical medium and discontinue
+  all use of and all access to other copies of Project Gutenberg-tm
+  works.
+
+* You provide, in accordance with paragraph 1.F.3, a full refund of
+  any money paid for a work or a replacement copy, if a defect in the
+  electronic work is discovered and reported to you within 90 days of
+  receipt of the work.
+
+* You comply with all other terms of this agreement for free
+  distribution of Project Gutenberg-tm works.
+
+1.E.9. If you wish to charge a fee or distribute a Project
+Gutenberg-tm electronic work or group of works on different terms than
+are set forth in this agreement, you must obtain permission in writing
+from the Project Gutenberg Literary Archive Foundation, the manager of
+the Project Gutenberg-tm trademark. Contact the Foundation as set
+forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+works not protected by U.S. copyright law in creating the Project
+Gutenberg-tm collection. Despite these efforts, Project Gutenberg-tm
+electronic works, and the medium on which they may be stored, may
+contain "Defects," such as, but not limited to, incomplete, inaccurate
+or corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged disk or
+other medium, a computer virus, or computer codes that damage or
+cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3. YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from. If you
+received the work on a physical medium, you must return the medium
+with your written explanation. The person or entity that provided you
+with the defective work may elect to provide a replacement copy in
+lieu of a refund. If you received the work electronically, the person
+or entity providing it to you may choose to give you a second
+opportunity to receive the work electronically in lieu of a refund. If
+the second copy is also defective, you may demand a refund in writing
+without further opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO
+OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of
+damages. If any disclaimer or limitation set forth in this agreement
+violates the law of the state applicable to this agreement, the
+agreement shall be interpreted to make the maximum disclaimer or
+limitation permitted by the applicable state law. The invalidity or
+unenforceability of any provision of this agreement shall not void the
+remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in
+accordance with this agreement, and any volunteers associated with the
+production, promotion and distribution of Project Gutenberg-tm
+electronic works, harmless from all liability, costs and expenses,
+including legal fees, that arise directly or indirectly from any of
+the following which you do or cause to occur: (a) distribution of this
+or any Project Gutenberg-tm work, (b) alteration, modification, or
+additions or deletions to any Project Gutenberg-tm work, and (c) any
+Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of
+computers including obsolete, old, middle-aged and new computers. It
+exists because of the efforts of hundreds of volunteers and donations
+from people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come. In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future
+generations. To learn more about the Project Gutenberg Literary
+Archive Foundation and how your efforts and donations can help, see
+Sections 3 and 4 and the Foundation information page at
+www.gutenberg.org
+
+Section 3. Information about the Project Gutenberg Literary
+Archive Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non-profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service. The Foundation's EIN or federal tax identification
+number is 64-6221541. Contributions to the Project Gutenberg Literary
+Archive Foundation are tax deductible to the full extent permitted by
+U.S. federal laws and your state's laws.
+
+The Foundation's business office is located at 809 North 1500 West,
+Salt Lake City, UT 84116, (801) 596-1887. Email contact links and up
+to date contact information can be found at the Foundation's website
+and official page at www.gutenberg.org/contact
+
+Section 4. Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without
+widespread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine-readable form accessible by the widest
+array of equipment including outdated equipment. Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular
+state visit www.gutenberg.org/donate
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg web pages for current donation
+methods and addresses. Donations are accepted in a number of other
+ways including checks, online payments and credit card donations. To
+donate, please visit: www.gutenberg.org/donate
+
+Section 5. General Information About Project Gutenberg-tm electronic works
+
+Professor Michael S. Hart was the originator of the Project
+Gutenberg-tm concept of a library of electronic works that could be
+freely shared with anyone. For forty years, he produced and
+distributed Project Gutenberg-tm eBooks with only a loose network of
+volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as not protected by copyright in
+the U.S. unless a copyright notice is included. Thus, we do not
+necessarily keep eBooks in compliance with any particular paper
+edition.
+
+Most people start at our website which has the main PG search
+facility: www.gutenberg.org
+
+This website includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/benches/medium.txt
+++ b/benches/medium.txt
@@ -1,0 +1,263 @@
+The Project Gutenberg eBook of Alice’s Adventures in Wonderland, by Lewis Carroll
+
+This eBook is for the use of anyone anywhere in the United States and
+most other parts of the world at no cost and with almost no restrictions
+whatsoever. You may copy it, give it away or re-use it under the terms
+of the Project Gutenberg License included with this eBook or online at
+www.gutenberg.org. If you are not located in the United States, you
+will have to check the laws of the country where you are located before
+using this eBook.
+
+Title: Alice’s Adventures in Wonderland
+
+Author: Lewis Carroll
+
+Release Date: January, 1991 [eBook #11]
+[Most recently updated: October 12, 2020]
+
+Language: English
+
+Character set encoding: UTF-8
+
+Produced by: Arthur DiBianca and David Widger
+
+*** START OF THE PROJECT GUTENBERG EBOOK ALICE’S ADVENTURES IN WONDERLAND ***
+
+[Illustration]
+
+
+
+
+Alice’s Adventures in Wonderland
+
+by Lewis Carroll
+
+THE MILLENNIUM FULCRUM EDITION 3.0
+
+Contents
+
+ CHAPTER I.     Down the Rabbit-Hole
+ CHAPTER II.    The Pool of Tears
+ CHAPTER III.   A Caucus-Race and a Long Tale
+ CHAPTER IV.    The Rabbit Sends in a Little Bill
+ CHAPTER V.     Advice from a Caterpillar
+ CHAPTER VI.    Pig and Pepper
+ CHAPTER VII.   A Mad Tea-Party
+ CHAPTER VIII.  The Queen’s Croquet-Ground
+ CHAPTER IX.    The Mock Turtle’s Story
+ CHAPTER X.     The Lobster Quadrille
+ CHAPTER XI.    Who Stole the Tarts?
+ CHAPTER XII.   Alice’s Evidence
+
+
+
+
+CHAPTER I.
+Down the Rabbit-Hole
+
+
+Alice was beginning to get very tired of sitting by her sister on the
+bank, and of having nothing to do: once or twice she had peeped into
+the book her sister was reading, but it had no pictures or
+conversations in it, “and what is the use of a book,” thought Alice
+“without pictures or conversations?”
+
+So she was considering in her own mind (as well as she could, for the
+hot day made her feel very sleepy and stupid), whether the pleasure of
+making a daisy-chain would be worth the trouble of getting up and
+picking the daisies, when suddenly a White Rabbit with pink eyes ran
+close by her.
+
+There was nothing so _very_ remarkable in that; nor did Alice think it
+so _very_ much out of the way to hear the Rabbit say to itself, “Oh
+dear! Oh dear! I shall be late!” (when she thought it over afterwards,
+it occurred to her that she ought to have wondered at this, but at the
+time it all seemed quite natural); but when the Rabbit actually _took a
+watch out of its waistcoat-pocket_, and looked at it, and then hurried
+on, Alice started to her feet, for it flashed across her mind that she
+had never before seen a rabbit with either a waistcoat-pocket, or a
+watch to take out of it, and burning with curiosity, she ran across the
+field after it, and fortunately was just in time to see it pop down a
+large rabbit-hole under the hedge.
+
+In another moment down went Alice after it, never once considering how
+in the world she was to get out again.
+
+The rabbit-hole went straight on like a tunnel for some way, and then
+dipped suddenly down, so suddenly that Alice had not a moment to think
+about stopping herself before she found herself falling down a very
+deep well.
+
+Either the well was very deep, or she fell very slowly, for she had
+plenty of time as she went down to look about her and to wonder what
+was going to happen next. First, she tried to look down and make out
+what she was coming to, but it was too dark to see anything; then she
+looked at the sides of the well, and noticed that they were filled with
+cupboards and book-shelves; here and there she saw maps and pictures
+hung upon pegs. She took down a jar from one of the shelves as she
+passed; it was labelled “ORANGE MARMALADE”, but to her great
+disappointment it was empty: she did not like to drop the jar for fear
+of killing somebody underneath, so managed to put it into one of the
+cupboards as she fell past it.
+
+“Well!” thought Alice to herself, “after such a fall as this, I shall
+think nothing of tumbling down stairs! How brave they’ll all think me
+at home! Why, I wouldn’t say anything about it, even if I fell off the
+top of the house!” (Which was very likely true.)
+
+Down, down, down. Would the fall _never_ come to an end? “I wonder how
+many miles I’ve fallen by this time?” she said aloud. “I must be
+getting somewhere near the centre of the earth. Let me see: that would
+be four thousand miles down, I think—” (for, you see, Alice had learnt
+several things of this sort in her lessons in the schoolroom, and
+though this was not a _very_ good opportunity for showing off her
+knowledge, as there was no one to listen to her, still it was good
+practice to say it over) “—yes, that’s about the right distance—but
+then I wonder what Latitude or Longitude I’ve got to?” (Alice had no
+idea what Latitude was, or Longitude either, but thought they were nice
+grand words to say.)
+
+Presently she began again. “I wonder if I shall fall right _through_
+the earth! How funny it’ll seem to come out among the people that walk
+with their heads downward! The Antipathies, I think—” (she was rather
+glad there _was_ no one listening, this time, as it didn’t sound at all
+the right word) “—but I shall have to ask them what the name of the
+country is, you know. Please, Ma’am, is this New Zealand or Australia?”
+(and she tried to curtsey as she spoke—fancy _curtseying_ as you’re
+falling through the air! Do you think you could manage it?) “And what
+an ignorant little girl she’ll think me for asking! No, it’ll never do
+to ask: perhaps I shall see it written up somewhere.”
+
+Down, down, down. There was nothing else to do, so Alice soon began
+talking again. “Dinah’ll miss me very much to-night, I should think!”
+(Dinah was the cat.) “I hope they’ll remember her saucer of milk at
+tea-time. Dinah my dear! I wish you were down here with me! There are
+no mice in the air, I’m afraid, but you might catch a bat, and that’s
+very like a mouse, you know. But do cats eat bats, I wonder?” And here
+Alice began to get rather sleepy, and went on saying to herself, in a
+dreamy sort of way, “Do cats eat bats? Do cats eat bats?” and
+sometimes, “Do bats eat cats?” for, you see, as she couldn’t answer
+either question, it didn’t much matter which way she put it. She felt
+that she was dozing off, and had just begun to dream that she was
+walking hand in hand with Dinah, and saying to her very earnestly,
+“Now, Dinah, tell me the truth: did you ever eat a bat?” when suddenly,
+thump! thump! down she came upon a heap of sticks and dry leaves, and
+the fall was over.
+
+Alice was not a bit hurt, and she jumped up on to her feet in a moment:
+she looked up, but it was all dark overhead; before her was another
+long passage, and the White Rabbit was still in sight, hurrying down
+it. There was not a moment to be lost: away went Alice like the wind,
+and was just in time to hear it say, as it turned a corner, “Oh my ears
+and whiskers, how late it’s getting!” She was close behind it when she
+turned the corner, but the Rabbit was no longer to be seen: she found
+herself in a long, low hall, which was lit up by a row of lamps hanging
+from the roof.
+
+There were doors all round the hall, but they were all locked; and when
+Alice had been all the way down one side and up the other, trying every
+door, she walked sadly down the middle, wondering how she was ever to
+get out again.
+
+Suddenly she came upon a little three-legged table, all made of solid
+glass; there was nothing on it except a tiny golden key, and Alice’s
+first thought was that it might belong to one of the doors of the hall;
+but, alas! either the locks were too large, or the key was too small,
+but at any rate it would not open any of them. However, on the second
+time round, she came upon a low curtain she had not noticed before, and
+behind it was a little door about fifteen inches high: she tried the
+little golden key in the lock, and to her great delight it fitted!
+
+Alice opened the door and found that it led into a small passage, not
+much larger than a rat-hole: she knelt down and looked along the
+passage into the loveliest garden you ever saw. How she longed to get
+out of that dark hall, and wander about among those beds of bright
+flowers and those cool fountains, but she could not even get her head
+through the doorway; “and even if my head would go through,” thought
+poor Alice, “it would be of very little use without my shoulders. Oh,
+how I wish I could shut up like a telescope! I think I could, if I only
+knew how to begin.” For, you see, so many out-of-the-way things had
+happened lately, that Alice had begun to think that very few things
+indeed were really impossible.
+
+There seemed to be no use in waiting by the little door, so she went
+back to the table, half hoping she might find another key on it, or at
+any rate a book of rules for shutting people up like telescopes: this
+time she found a little bottle on it, (“which certainly was not here
+before,” said Alice,) and round the neck of the bottle was a paper
+label, with the words “DRINK ME,” beautifully printed on it in large
+letters.
+
+It was all very well to say “Drink me,” but the wise little Alice was
+not going to do _that_ in a hurry. “No, I’ll look first,” she said,
+“and see whether it’s marked ‘_poison_’ or not”; for she had read
+several nice little histories about children who had got burnt, and
+eaten up by wild beasts and other unpleasant things, all because they
+_would_ not remember the simple rules their friends had taught them:
+such as, that a red-hot poker will burn you if you hold it too long;
+and that if you cut your finger _very_ deeply with a knife, it usually
+bleeds; and she had never forgotten that, if you drink much from a
+bottle marked “poison,” it is almost certain to disagree with you,
+sooner or later.
+
+However, this bottle was _not_ marked “poison,” so Alice ventured to
+taste it, and finding it very nice, (it had, in fact, a sort of mixed
+flavour of cherry-tart, custard, pine-apple, roast turkey, toffee, and
+hot buttered toast,) she very soon finished it off.
+
+*      *      *      *      *      *      *
+
+    *      *      *      *      *      *
+
+*      *      *      *      *      *      *
+
+
+“What a curious feeling!” said Alice; “I must be shutting up like a
+telescope.”
+
+And so it was indeed: she was now only ten inches high, and her face
+brightened up at the thought that she was now the right size for going
+through the little door into that lovely garden. First, however, she
+waited for a few minutes to see if she was going to shrink any further:
+she felt a little nervous about this; “for it might end, you know,”
+said Alice to herself, “in my going out altogether, like a candle. I
+wonder what I should be like then?” And she tried to fancy what the
+flame of a candle is like after the candle is blown out, for she could
+not remember ever having seen such a thing.
+
+After a while, finding that nothing more happened, she decided on going
+into the garden at once; but, alas for poor Alice! when she got to the
+door, she found she had forgotten the little golden key, and when she
+went back to the table for it, she found she could not possibly reach
+it: she could see it quite plainly through the glass, and she tried her
+best to climb up one of the legs of the table, but it was too slippery;
+and when she had tired herself out with trying, the poor little thing
+sat down and cried.
+
+“Come, there’s no use in crying like that!” said Alice to herself,
+rather sharply; “I advise you to leave off this minute!” She generally
+gave herself very good advice, (though she very seldom followed it),
+and sometimes she scolded herself so severely as to bring tears into
+her eyes; and once she remembered trying to box her own ears for having
+cheated herself in a game of croquet she was playing against herself,
+for this curious child was very fond of pretending to be two people.
+“But it’s no use now,” thought poor Alice, “to pretend to be two
+people! Why, there’s hardly enough of me left to make _one_ respectable
+person!”
+
+Soon her eye fell on a little glass box that was lying under the table:
+she opened it, and found in it a very small cake, on which the words
+“EAT ME” were beautifully marked in currants. “Well, I’ll eat it,” said
+Alice, “and if it makes me grow larger, I can reach the key; and if it
+makes me grow smaller, I can creep under the door; so either way I’ll
+get into the garden, and I don’t care which happens!”
+
+She ate a little bit, and said anxiously to herself, “Which way? Which
+way?”, holding her hand on the top of her head to feel which way it was
+growing, and she was quite surprised to find that she remained the same
+size: to be sure, this generally happens when one eats cake, but Alice
+had got so much into the way of expecting nothing but out-of-the-way
+things to happen, that it seemed quite dull and stupid for life to go
+on in the common way.
+
+So she set to work, and very soon finished off the cake.

--- a/benches/small.txt
+++ b/benches/small.txt
@@ -1,0 +1,10 @@
+Consider the lilies of the field
+And why take ye thought for raiment? Consider the lilies of the field, how they grow; they toil not, neither do they spin:
+
+And yet I say unto you, That even Solomon in all his glory was not arrayed like one of these.
+
+Wherefore, if God so clothe the grass of the field, which today is, and tomorrow is cast into the oven, shall he not much more clothe you, O ye of little faith? Therefore, take no thought, saying, What shall we eat? or, What shall we drink? or, Wherewithal shall we be clothed?
+
+For your heavenly Father knoweth that ye have need of all these things . . .
+
+Take therefore no thought for the morrow: for the morrow shall take thought for the things of itself. Sufficient unto the day is the evil thereof.

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -73,6 +73,7 @@ async fn try_main() -> Result<()> {
 
             let mut resp = client.check(&req).await?;
 
+            #[cfg(feature = "cli")]
             if req.more_context {
                 use crate::check::CheckResponseWithContext;
                 let text = req.get_text();

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -71,11 +71,15 @@ async fn try_main() -> Result<()> {
                 return Ok(());
             }
 
-            writeln!(
-                &stdout,
-                "{}",
-                serde_json::to_string_pretty(&client.check(&req).await?)?
-            )?;
+            let mut resp = client.check(&req).await?;
+
+            if req.more_context {
+                use crate::check::CheckResponseWithContext;
+                let text = req.get_text();
+                resp = CheckResponseWithContext::new(text, resp).into();
+            }
+
+            writeln!(&stdout, "{}", serde_json::to_string_pretty(&resp)?)?;
         }
         Some(("languages", _sub_matches)) => {
             writeln!(

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -487,6 +487,52 @@ pub struct CheckResponse {
     pub warnings: Option<Warnings>,
 }
 
+impl CheckResponse {
+    fn iter_matches(&self) -> std::slice::Iter<'_, Match> {
+        self.matches.iter()
+    }
+
+    fn iter_matches_mut(&mut self) -> std::slice::IterMut<'_, Match> {
+        self.matches.iter_mut()
+    }
+}
+
+struct CheckResponseWithContext {
+    text: String,
+    response: CheckResponse,
+    text_length: usize,
+}
+
+impl CheckResponseWithContext {
+    fn new(text: String, response: CheckResponse) -> Self {
+        let text_length = text.chars().count();
+        Self {
+            text,
+            response,
+            text_length,
+        }
+    }
+
+    fn iter_matches(&self) -> std::slice::Iter<'_, Match> {
+        self.response.iter_matches()
+    }
+
+    fn iter_matches_mut(&mut self) -> std::slice::IterMut<'_, Match> {
+        self.response.iter_matches_mut()
+    }
+
+    fn append(mut self, mut other: Self) -> Self {
+        let offset = self.text_length;
+        for m in other.iter_matches_mut() {
+            m.offset += offset;
+        }
+
+        self.text.push_str(other.text.as_str());
+        self.text_length += other.text_length;
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -151,6 +151,10 @@ pub struct CheckRequest {
     #[clap(short = 'r', long, takes_value = false)]
     /// If present, raw JSON output will be printed instead of annotated text.
     pub raw: bool,
+    #[cfg(feature = "cli"))]
+    #[clap(short = 'c', long, takes_value = false)]
+    /// If present, context (i.e., line number and line offset) will be added to response.
+    pub with_context: bool,
     #[cfg_attr(feature = "cli", clap(short = 't', long, conflicts_with = "data",))]
     /// The text to be checked. This or 'data' is required.
     pub text: Option<String>,

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -292,7 +292,7 @@ impl CheckRequest {
 
 /// Responses
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[non_exhaustive]
 /// Detected language from check request.
 pub struct DetectedLanguage {
@@ -308,7 +308,7 @@ pub struct DetectedLanguage {
     pub source: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// Language information in check response.
@@ -487,7 +487,7 @@ pub struct Warnings {
     pub incomplete_results: bool,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// LanguageTool POST check response.
@@ -518,7 +518,7 @@ impl CheckResponse {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 /// Check response with additional context.
 ///
 /// This structure exists to keep a link between a check response
@@ -590,6 +590,7 @@ impl CheckResponseWithContext {
     }
 }
 
+#[cfg(feature = "cli")]
 impl From<CheckResponseWithContext> for CheckResponse {
     fn from(mut resp: CheckResponseWithContext) -> Self {
         let iter: MatchPositions<'_, std::slice::IterMut<'_, Match>> = (&mut resp).into();

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// Requests
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
 /// A portion of text to be checked.
 pub struct DataAnnotation {
@@ -63,7 +63,7 @@ impl DataAnnotation {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
 #[non_exhaustive]
 /// Alternative text to be checked.
 pub struct Data {
@@ -100,7 +100,7 @@ impl std::str::FromStr for Data {
     }
 }
 
-#[derive(Clone, Deserialize, Debug, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 /// Possible levels for additional rules.
@@ -137,7 +137,7 @@ impl std::str::FromStr for Level {
 }
 
 #[cfg_attr(feature = "cli", derive(Parser))]
-#[derive(Clone, Deserialize, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, Debug, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// LanguageTool POST check request.
@@ -292,7 +292,7 @@ impl CheckRequest {
 
 /// Responses
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 /// Detected language from check request.
 pub struct DetectedLanguage {
@@ -308,7 +308,7 @@ pub struct DetectedLanguage {
     pub source: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// Language information in check response.
@@ -321,7 +321,7 @@ pub struct LanguageResponse {
     pub name: String,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
 /// Match context in check response.
 pub struct Context {
@@ -334,7 +334,7 @@ pub struct Context {
 }
 
 #[cfg(feature = "cli")]
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
 /// More context, post-processed in check response.
 pub struct MoreContext {
@@ -344,7 +344,7 @@ pub struct MoreContext {
     pub line_offset: usize,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
 /// Possible replacement for a given match in check response.
 pub struct Replacement {
@@ -364,7 +364,7 @@ impl From<&str> for Replacement {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
 /// A rule category.
 pub struct Category {
@@ -374,7 +374,7 @@ pub struct Category {
     pub name: String,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
 /// A possible url of a rule in a check response.
 pub struct Url {
@@ -382,7 +382,7 @@ pub struct Url {
     pub value: String,
 }
 
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// The rule that was not satisfied in a given match.
@@ -407,7 +407,7 @@ pub struct Rule {
     pub urls: Option<Vec<Url>>,
 }
 
-#[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// Type of a given match.
@@ -416,7 +416,7 @@ pub struct Type {
     pub type_name: String,
 }
 
-#[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// Grammatical error match.
@@ -455,7 +455,7 @@ pub struct Match {
     pub type_: Type,
 }
 
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// LanguageTool software details.
@@ -478,7 +478,7 @@ pub struct Software {
     pub version: String,
 }
 
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// Warnings about check response.
@@ -487,7 +487,7 @@ pub struct Warnings {
     pub incomplete_results: bool,
 }
 
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// LanguageTool POST check response.
@@ -518,7 +518,7 @@ impl CheckResponse {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// Check response with additional context.
 ///
 /// This structure exists to keep a link between a check response

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -40,6 +40,9 @@ pub enum Error {
     #[error(transparent)]
     /// Any other error from requests (see [reqwest::Error])
     Reqwest(#[from] reqwest::Error),
+    #[error(transparent)]
+    /// Error from reading environ variable (see [std::env::VarError])
+    VarError(#[from] std::env::VarError),
 }
 
 /// Result type alias with error type defined above (see [Error]).

--- a/src/lib/languages.rs
+++ b/src/lib/languages.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// Language information

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -6,7 +6,7 @@
 //! # Note
 //!
 //! Most structures in this library are marked with
-//! ```rust
+//! ```ignore
 //! #[non_exhaustive]
 //! ```
 //! to indicate that they are likely to change in the future.

--- a/src/lib/server.rs
+++ b/src/lib/server.rs
@@ -254,7 +254,6 @@ impl Default for ServerCli {
     }
 }
 
-
 impl ServerCli {
     /// Create a new [ServeCli] instance from environ variables:
     /// - LANGUAGETOOL_HOSTNAME
@@ -569,7 +568,6 @@ impl ServerClient {
         Self::from_cli(ServerCli::from_env_or_default())
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/lib/server.rs
+++ b/src/lib/server.rs
@@ -46,7 +46,7 @@ pub fn is_port(v: &str) -> Result<()> {
     })
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// A Java property file (one key=value entry per line) with values listed below.
@@ -181,7 +181,7 @@ impl Default for ConfigFile {
 }
 
 #[cfg_attr(feature = "cli", derive(Parser))]
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 /// Server parameters that are to be used when instantiating a LanguageTool server
 pub struct ServerParameters {
@@ -222,7 +222,7 @@ impl Default for ServerParameters {
 }
 
 #[cfg_attr(feature = "cli", derive(Parser))]
-#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 /// Hostname and (optional) port to connect to a LanguageTool server.
 ///
 /// To use your local server instead of online api, set:

--- a/src/lib/server.rs
+++ b/src/lib/server.rs
@@ -357,10 +357,20 @@ impl ServerClient {
         let text = request.get_text();
         let resp = self.check(request).await?;
 
+        use crate::check::CheckResponseWithContext;
+
+        for (lineno, lineof, m) in
+            CheckResponseWithContext::new(text.clone(), resp.clone()).iter_match_positions()
+        {
+            println!(
+                "Error found at line: {}, offset: {}, length: {}.",
+                lineno, lineof, m.length
+            );
+        }
+
         if resp.matches.is_empty() {
             return Ok("Not error were found in provided text".to_string());
         }
-
         let replacements: Vec<_> = resp
             .matches
             .iter()

--- a/src/lib/server.rs
+++ b/src/lib/server.rs
@@ -378,17 +378,6 @@ impl ServerClient {
         let text = request.get_text();
         let resp = self.check(request).await?;
 
-        use crate::check::CheckResponseWithContext;
-
-        for (lineno, lineof, m) in
-            CheckResponseWithContext::new(text.clone(), resp.clone()).iter_match_positions()
-        {
-            println!(
-                "Error found at line: {}, offset: {}, length: {}.",
-                lineno, lineof, m.length
-            );
-        }
-
         if resp.matches.is_empty() {
             return Ok("Not error were found in provided text".to_string());
         }

--- a/src/lib/words.rs
+++ b/src/lib/words.rs
@@ -26,7 +26,7 @@ pub fn is_word(v: &str) -> Result<(), String> {
 }
 
 #[cfg_attr(feature = "cli", derive(Parser))]
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// Login arguments required by the API.
@@ -40,7 +40,7 @@ pub struct LoginArgs {
 }
 
 #[cfg_attr(feature = "cli", derive(Parser))]
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 /// LanguageTool GET words request.
 ///
@@ -61,7 +61,7 @@ pub struct WordsRequest {
 }
 
 #[cfg_attr(feature = "cli", derive(Parser))]
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 /// LanguageTool POST words add request.
 ///
@@ -80,7 +80,7 @@ pub struct WordsAddRequest {
 }
 
 #[cfg_attr(feature = "cli", derive(Parser))]
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 /// LanguageTool POST words delete request.
 ///
@@ -98,7 +98,7 @@ pub struct WordsDeleteRequest {
     pub dict: Option<String>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 /// LanguageTool GET words response.
 pub struct WordsResponse {
@@ -106,7 +106,7 @@ pub struct WordsResponse {
     words: Vec<String>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 /// LanguageTool POST word add response.
 pub struct WordsAddResponse {
@@ -114,7 +114,7 @@ pub struct WordsAddResponse {
     added: bool,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 /// LanguageTool POST word delete response.
 pub struct WordsDeleteResponse {

--- a/tests/match_positions.rs
+++ b/tests/match_positions.rs
@@ -1,0 +1,69 @@
+use languagetool_rust::{
+    check::{CheckRequest, CheckResponseWithContext},
+    server::ServerClient,
+};
+
+#[macro_export]
+macro_rules! test_match_positions{
+    ($name:ident, $text:expr, $(($x:expr, $y:expr)),*) => {
+        #[tokio::test]
+        async fn $name()  -> Result<(), Box<dyn std::error::Error>> {
+
+            let client = ServerClient::from_env_or_default();
+            let req = CheckRequest::default().with_text($text.to_string());
+            let resp = client.check(&req).await.unwrap();
+            let resp = CheckResponseWithContext::new(req.get_text(), resp);
+
+            let expected = vec![$(($x, $y)),*];
+            let got = resp.iter_match_positions();
+
+            assert_eq!(expected.len(), resp.response.matches.len());
+
+            for ((lineno, lineof), got) in expected.iter().zip(got) {
+                assert_eq!(*lineno, got.0);
+                assert_eq!(*lineof, got.1);
+            }
+
+            Ok(())
+        }
+    };
+}
+
+test_match_positions!(
+    test_match_positions_1,
+    "Some phrase with a smal mistake.
+i can drive a car",
+    (1, 19),
+    (2, 0)
+);
+
+test_match_positions!(
+    test_match_positions_2,
+    "Some phrase with 
+a smal mistake. i can 
+drive a car",
+    (2, 2),
+    (2, 16)
+);
+
+test_match_positions!(
+    test_match_positions_3,
+    "  Some phrase with a smal
+mistake.
+
+  i can drive a car",
+    (1, 0),
+    (1, 21),
+    (4, 0),
+    (4, 2)
+);
+
+test_match_positions!(
+    test_match_positions_4,
+    "Some phrase with a smal mistake.
+i can drive a car
+Some phrase with a smal mistake.",
+    (1, 19),
+    (2, 0),
+    (3, 19)
+);

--- a/tests/match_positions.rs
+++ b/tests/match_positions.rs
@@ -4,7 +4,7 @@ use languagetool_rust::{
 };
 
 #[macro_export]
-macro_rules! test_match_positions{
+macro_rules! test_match_positions {
     ($name:ident, $text:expr, $(($x:expr, $y:expr)),*) => {
         #[tokio::test]
         async fn $name()  -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
This PR adds new features to facilitate the use of `CheckReponse` structs.

Indeed, it is now possible to carry information about line number, line offset, while also splitting text into multiple requests and merging them back into one response.

To do:

- [x] Update changelog
- [ ] Create release
- [x] Create integration tests for basic position checking
- ~~[ ] Create an integration example for doc purpose~~
- [x] Add some CLI command / option that allows to retrieve this new information
- ~~[ ] Allow automated split in text and recombination after responses are received~~