### PR TITLE
Skip useless serializings

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [jeertmans]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased](https://github.com/jeertmans/languagetool-rust/compare/v1.3.0...HEAD)
+
+### Chore
+
+- Created founding link. [#19](https://github.com/jeertmans/languagetool-rust/pull/19)
+- Added two related projets. [#21](https://github.com/jeertmans/languagetool-rust/pull/21)
+
 ## [1.3.0](https://github.com/jeertmans/languagetool-rust/compare/v1.2.0...v1.3.0)
 
 ### Chore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Created founding link. [#19](https://github.com/jeertmans/languagetool-rust/pull/19)
 - Added two related projets. [#21](https://github.com/jeertmans/languagetool-rust/pull/21)
 
+### Fixed
+
+- Stopped serializing useless fields. [#17](https://github.com/jeertmans/languagetool-rust/pull/17)
+
 ## [1.3.0](https://github.com/jeertmans/languagetool-rust/compare/v1.2.0...v1.3.0)
 
 ### Chore

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 Here are listed some projects that use LTRS.
 
-- *W.I.P.*
+- [`null-ls`](https://github.com/jose-elias-alvarez/null-ls.nvim): Neovim plugin with LTRS builtin ([to be merged](https://github.com/jose-elias-alvarez/null-ls.nvim/pull/997))
+- [`languagetool-code-comments`](https://github.com/dustinblackman/languagetool-code-comments): uses LTRS to check for grammar errors within code comments
 
 *Do you use LTRS in your project? Contact me so I can add it to the list!*
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -58,6 +58,7 @@ async fn try_main() -> Result<()> {
     let client = ServerClient::from_arg_matches(&matches)?.with_max_suggestions(5);
     let stdout = std::io::stdout();
 
+    #[allow(clippy::significant_drop_in_scrutinee)]
     match matches.subcommand() {
         Some(("check", sub_matches)) => {
             let mut req = CheckRequest::from_arg_matches(sub_matches)?;

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -149,10 +149,12 @@ impl std::str::FromStr for Level {
 pub struct CheckRequest {
     #[cfg(all(feature = "cli", feature = "annotate"))]
     #[clap(short = 'r', long, takes_value = false)]
+    #[serde(skip_serializing)]
     /// If present, raw JSON output will be printed instead of annotated text.
     pub raw: bool,
     #[cfg(feature = "cli")]
     #[clap(short = 'm', long, takes_value = false)]
+    #[serde(skip_serializing)]
     /// If present, more context (i.e., line number and line offset) will be added to response.
     pub more_context: bool,
     #[cfg_attr(feature = "cli", clap(short = 't', long, conflicts_with = "data",))]

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -122,6 +122,16 @@ impl Default for Level {
 
 impl Level {
     /// Return `true` if current level is the default one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use languagetool_rust::check::Level;
+    ///
+    /// let level: Level = Default::default();
+    ///
+    /// assert!(level.is_default());
+    /// ```
     pub fn is_default(&self) -> bool {
         *self == Level::default()
     }
@@ -147,9 +157,9 @@ impl std::str::FromStr for Level {
 #[derive(Clone, Deserialize, Debug, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-/// `LanguageTool` POST check request.
+/// LanguageTool POST check request.
 ///
-/// The main feature - check a text with `LanguageTool` for possible style and grammar issues.
+/// The main feature - check a text with LanguageTool for possible style and grammar issues.
 ///
 /// The structure below tries to follow as closely as possible the JSON API described
 /// [here](https://languagetool.org/http-api/swagger-ui/#!/default/post_check).
@@ -245,8 +255,9 @@ pub struct CheckRequest {
     pub level: Level,
 }
 
+#[inline]
 fn is_false(b: &bool) -> bool {
-    *b == false
+    !(*b)
 }
 
 impl CheckRequest {
@@ -318,6 +329,7 @@ impl CheckRequest {
 
 /// Responses
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[non_exhaustive]
 /// Detected language from check request.
@@ -484,7 +496,7 @@ pub struct Match {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-/// `LanguageTool` software details.
+/// LanguageTool software details.
 pub struct Software {
     /// LanguageTool API version
     pub api_version: usize,
@@ -516,7 +528,7 @@ pub struct Warnings {
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-/// `LanguageTool` POST check response.
+/// LanguageTool POST check response.
 pub struct CheckResponse {
     /// Language information
     pub language: LanguageResponse,
@@ -618,6 +630,7 @@ impl CheckResponseWithContext {
 
 #[cfg(feature = "cli")]
 impl From<CheckResponseWithContext> for CheckResponse {
+    #[allow(clippy::needless_borrow)]
     fn from(mut resp: CheckResponseWithContext) -> Self {
         let iter: MatchPositions<'_, std::slice::IterMut<'_, Match>> = (&mut resp).into();
 

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -158,9 +158,11 @@ pub struct CheckRequest {
     /// If present, more context (i.e., line number and line offset) will be added to response.
     pub more_context: bool,
     #[cfg_attr(feature = "cli", clap(short = 't', long, conflicts_with = "data",))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// The text to be checked. This or 'data' is required.
     pub text: Option<String>,
     #[cfg_attr(feature = "cli", clap(short = 'd', long, conflicts_with = "text"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// The text to be checked, given as a JSON document that specifies what's text and what's markup. This or 'text' is required.
     ///
     /// Markup will be ignored when looking for errors. Example text:
@@ -189,32 +191,41 @@ pub struct CheckRequest {
     /// For languages with variants (English, German, Portuguese) spell checking will only be activated when you specify the variant, e.g. `en-GB` instead of just `en`.
     pub language: String,
     #[cfg_attr(feature = "cli", clap(short = 'u', long))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Set to get Premium API access: Your username/email as used to log in at languagetool.org.
     pub username: Option<String>,
     #[cfg_attr(feature = "cli", clap(short = 'k', long))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Set to get Premium API access: [your API key](https://languagetool.org/editor/settings/api)
     pub api_key: Option<String>,
     #[cfg_attr(feature = "cli", clap(long, multiple_values = true))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Comma-separated list of dictionaries to include words from; uses special default dictionary if this is unset
     pub dicts: Option<Vec<String>>,
     #[cfg_attr(feature = "cli", clap(long))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// A language code of the user's native language, enabling false friends checks for some language pairs.
     pub mother_tongue: Option<String>,
     #[cfg_attr(feature = "cli", clap(long, multiple_values = true))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Comma-separated list of preferred language variants.
     ///
     /// The language detector used with `language=auto` can detect e.g. English, but it cannot decide whether British English or American English is used. Thus this parameter can be used to specify the preferred variants like `en-GB` and `de-AT`. Only available with `language=auto`. You should set variants for at least German and English, as otherwise the spell checking will not work for those, as no spelling dictionary can be selected for just `en` or `de`.
     pub preferred_variants: Option<Vec<String>>,
     #[cfg_attr(feature = "cli", clap(long, multiple_values = true))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// IDs of rules to be enabled, comma-separated
     pub enabled_rules: Option<Vec<String>>,
     #[cfg_attr(feature = "cli", clap(long, multiple_values = true))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// IDs of rules to be disabled, comma-separated
     pub disabled_rules: Option<Vec<String>>,
     #[cfg_attr(feature = "cli", clap(long, multiple_values = true))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// IDs of categories to be enabled, comma-separated
     pub enabled_categories: Option<Vec<String>>,
     #[cfg_attr(feature = "cli", clap(long, multiple_values = true))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// IDs of categories to be disabled, comma-separated
     pub disabled_categories: Option<Vec<String>>,
     #[cfg_attr(feature = "cli", clap(long, takes_value = false))]

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -120,6 +120,13 @@ impl Default for Level {
     }
 }
 
+impl Level {
+    /// Return `true` if current level is the default one.
+    pub fn is_default(&self) -> bool {
+        *self == Level::default()
+    }
+}
+
 #[cfg(feature = "cli")]
 impl std::str::FromStr for Level {
     type Err = clap::Error;
@@ -229,11 +236,17 @@ pub struct CheckRequest {
     /// IDs of categories to be disabled, comma-separated
     pub disabled_categories: Option<Vec<String>>,
     #[cfg_attr(feature = "cli", clap(long, takes_value = false))]
+    #[serde(skip_serializing_if = "is_false")]
     /// If true, only the rules and categories whose IDs are specified with `enabledRules` or `enabledCategories` are enabled.
     pub enabled_only: bool,
     #[cfg_attr(feature = "cli", clap(long, default_value = "default"))]
+    #[serde(skip_serializing_if = "Level::is_default")]
     /// If set to `picky`, additional rules will be activated, i.e. rules that you might only find useful when checking formal text.
     pub level: Level,
+}
+
+fn is_false(b: &bool) -> bool {
+    *b == false
 }
 
 impl CheckRequest {

--- a/src/lib/languages.rs
+++ b/src/lib/languages.rs
@@ -15,7 +15,7 @@ pub struct Language {
     pub long_code: String,
 }
 
-/// `LanguageTool` GET languages response.
+/// LanguageTool GET languages response.
 ///
 /// List of all supported languages.
 pub type LanguagesResponse = Vec<Language>;

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,5 +1,9 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
+#![warn(
+     clippy::must_use_candidate,
+)]
+#![allow(clippy::doc_markdown, clippy::module_name_repetitions)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../../README.md")]
 //!

--- a/src/lib/server.rs
+++ b/src/lib/server.rs
@@ -360,7 +360,7 @@ impl ServerClient {
                                         format!("... ({} not shown)", len - max).into();
                                     m.replacements.truncate(max + 1);
                                 }
-                            })
+                            });
                         }
                         resp
                     }),

--- a/src/lib/words.rs
+++ b/src/lib/words.rs
@@ -42,7 +42,7 @@ pub struct LoginArgs {
 #[cfg_attr(feature = "cli", derive(Parser))]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
-/// `LanguageTool` GET words request.
+/// LanguageTool GET words request.
 ///
 /// List words in the user's personal dictionaries.
 pub struct WordsRequest {
@@ -64,7 +64,7 @@ pub struct WordsRequest {
 #[cfg_attr(feature = "cli", derive(Parser))]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
-/// `LanguageTool` POST words add request.
+/// LanguageTool POST words add request.
 ///
 /// Add a word to one of the user's personal dictionaries. Please note that this feature is considered to be used for personal dictionaries which must not contain more than 500 words. If this is an issue for you, please contact us.
 pub struct WordsAddRequest {
@@ -84,7 +84,7 @@ pub struct WordsAddRequest {
 #[cfg_attr(feature = "cli", derive(Parser))]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
-/// `LanguageTool` POST words delete request.
+/// LanguageTool POST words delete request.
 ///
 /// Remove a word from one of the user's personal dictionaries.
 pub struct WordsDeleteRequest {
@@ -103,7 +103,7 @@ pub struct WordsDeleteRequest {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
-/// `LanguageTool` GET words response.
+/// LanguageTool GET words response.
 pub struct WordsResponse {
     /// List of words
     words: Vec<String>,
@@ -111,7 +111,7 @@ pub struct WordsResponse {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
-/// `LanguageTool` POST word add response.
+/// LanguageTool POST word add response.
 pub struct WordsAddResponse {
     /// `true` if word was correctly added
     added: bool,
@@ -119,7 +119,7 @@ pub struct WordsAddResponse {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
-/// `LanguageTool` POST word delete response.
+/// LanguageTool POST word delete response.
 pub struct WordsDeleteResponse {
     /// `true` if word was correctly removed
     deleted: bool,

--- a/src/lib/words.rs
+++ b/src/lib/words.rs
@@ -56,6 +56,7 @@ pub struct WordsRequest {
     /// Login arguments
     pub login: LoginArgs,
     #[cfg_attr(feature = "cli", clap(long))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Comma-separated list of dictionaries to include words from; uses special default dictionary if this is unset
     pub dicts: Option<Vec<String>>,
 }
@@ -74,6 +75,7 @@ pub struct WordsAddRequest {
     /// Login arguments
     pub login: LoginArgs,
     #[cfg_attr(feature = "cli", clap(long))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Name of the dictionary to add the word to; non-existent dictionaries are created after
     /// calling this; if unset, adds to special default dictionary
     dict: Option<String>,
@@ -93,6 +95,7 @@ pub struct WordsDeleteRequest {
     /// Login arguments
     pub login: LoginArgs,
     #[cfg_attr(feature = "cli", clap(long))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Name of the dictionary to add the word to; non-existent dictionaries are created after
     /// calling this; if unset, adds to special default dictionary
     pub dict: Option<String>,


### PR DESCRIPTION
This skips serializing None, false, default and additional content, not needed by requests.

In short, this reduces the overhead size of check requests from 291 to 29 bytes, when serialized as JSON string.