### PR TITLE
feat(lib): splitting text based on length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added (regex) validator for language code. [#27](https://github.com/jeertmans/languagetool-rust/pull/27)
 - Added cli requirements for `username`/`api_key` pair. [#16](https://github.com/jeertmans/languagetool-rust/pull/16), [#30](https://github.com/jeertmans/languagetool-rust/pull/30)
 - Added a `CommandNotFound` error variant for when docker is not found. [#52](https://github.com/jeertmans/languagetool-rust/pull/52)
+- Added a `split_len` function. [#18](https://github.com/jeertmans/languagetool-rust/pull/18)
 
 ### Changed
 

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -265,6 +265,7 @@ impl Level {
 ///     "I have so many friends.\nThey are very funny.\nI think I am very lucky to have them.\n\n",
 ///     "One day, I will write them a poem.\nBut, in the meantime, I write code.\n"]);
 /// ```
+#[must_use]
 pub fn split_len<'source>(s: &'source str, n: usize, pat: &str) -> Vec<&'source str> {
     let mut vec: Vec<&'source str> = Vec::with_capacity(s.len() / n);
     let mut splits = s.split_inclusive(pat);

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -220,6 +220,60 @@ impl Level {
 
 #[cfg_attr(feature = "cli", derive(Args))]
 #[derive(Clone, Deserialize, Debug, PartialEq, Eq, Serialize)]
+/// Split string into as few fragments as possible, where each fragment contains
+/// (if possible) a maximum of `n` characters.
+///
+/// # Examples
+///
+/// ```
+/// # use languagetool_rust::check::split_len;
+/// let s = "I have so many friends.
+/// They are very funny.
+/// I think I am very lucky to have them.
+/// One day, I will write them a poem.
+/// But, in the meantime, I write code.
+/// ";
+///
+/// let split = split_len(&s, 40);
+///
+/// assert_eq!(split.join(""), s);
+/// assert_eq!(split, vec![
+///     "I have so many friends.\n",
+///     "They are very funny.\n",
+///     "I think I am very lucky to have them.\n",
+///     "One day, I will write them a poem.\n",
+///     "But, in the meantime, I write code.\n"]);
+///
+/// let split = split_len(&s, 80);
+///
+/// assert_eq!(split, vec![
+///     "I have so many friends.\nThey are very funny.\n",
+///     "I think I am very lucky to have them.\nOne day, I will write them a poem.\n",
+///     "But, in the meantime, I write code.\n"]);
+/// ```
+pub fn split_len<'source>(s: &'source str, n: usize) -> Vec<&'source str> {
+    let mut vec: Vec<&'source str> = Vec::new();
+
+    let mut start = 0;
+    let mut end = start;
+
+    for (index, _) in s.match_indices('\n') {
+        if index - start > n {
+            vec.push(&s[start..=end]);
+            start = end + 1;
+        }
+        end = index;
+    }
+
+    if end != s.len() {
+        vec.push(&s[start..]);
+    }
+
+    vec
+}
+
+#[cfg_attr(feature = "cli", derive(Parser))]
+#[derive(Clone, Deserialize, Debug, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 /// LanguageTool POST check request.

--- a/src/lib/cli.rs
+++ b/src/lib/cli.rs
@@ -12,7 +12,9 @@ use crate::words::WordsSubcommand;
 use clap::{CommandFactory, Parser, Subcommand};
 use is_terminal::IsTerminal;
 use std::io::{self, Write};
-use termcolor::{ColorChoice, StandardStream, WriteColor};
+use termcolor::{ColorChoice, StandardStream};
+#[cfg(feature = "annotate")]
+use termcolor::WriteColor;
 
 /// Read lines from standard input and write to buffer string.
 ///

--- a/src/lib/cli.rs
+++ b/src/lib/cli.rs
@@ -12,9 +12,9 @@ use crate::words::WordsSubcommand;
 use clap::{CommandFactory, Parser, Subcommand};
 use is_terminal::IsTerminal;
 use std::io::{self, Write};
-use termcolor::{ColorChoice, StandardStream};
 #[cfg(feature = "annotate")]
 use termcolor::WriteColor;
+use termcolor::{ColorChoice, StandardStream};
 
 /// Read lines from standard input and write to buffer string.
 ///


### PR DESCRIPTION
This features allows to split text into fragments so that, hopefully, each fragment has a length lower than a given value.

This is especially useful since the LT api limits the # of characters to 1500 for online usage.