### PR TITLE
chore(lint): add `#[must_use]` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Created founding link. [#19](https://github.com/jeertmans/languagetool-rust/pull/19)
 - Added two related projets. [#21](https://github.com/jeertmans/languagetool-rust/pull/21)
+- Added `#[must_use]` flag to most structures, to please clippy pendantic. [#29](https://github.com/jeertmans/languagetool-rust/pull/21)
 
 ### Added
 

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -98,6 +98,7 @@ impl Default for DataAnnotation {
 impl DataAnnotation {
     #[inline]
     /// Instantiate a new `DataAnnotation` with text only
+    #[must_use]
     pub fn new_text(text: String) -> Self {
         Self {
             interpret_as: None,
@@ -108,6 +109,7 @@ impl DataAnnotation {
 
     #[inline]
     /// Instantiate a new `DataAnnotation` with markup only
+    #[must_use]
     pub fn new_markup(markup: String) -> Self {
         Self {
             interpret_as: None,
@@ -118,6 +120,7 @@ impl DataAnnotation {
 
     #[inline]
     /// Instantiate a new `DataAnnotation` with markup and its interpretation
+    #[must_use]
     pub fn new_interpreted_markup(markup: String, interpret_as: String) -> Self {
         Self {
             interpret_as: Some(interpret_as),
@@ -196,6 +199,7 @@ impl Level {
     ///
     /// assert!(level.is_default());
     /// ```
+    #[must_use]
     pub fn is_default(&self) -> bool {
         *self == Level::default()
     }
@@ -349,6 +353,7 @@ fn is_false(b: &bool) -> bool {
 impl CheckRequest {
     #[inline]
     /// Create a default check requests that matches default values from CLI options
+    #[must_use]
     pub fn default() -> Self {
         Self {
             language: "auto".to_owned(),
@@ -357,6 +362,7 @@ impl CheckRequest {
     }
 
     /// Set the text to be checked and removed potential data field
+    #[must_use]
     pub fn with_text(mut self, text: String) -> Self {
         self.text = Some(text);
         self.data = None;
@@ -364,6 +370,7 @@ impl CheckRequest {
     }
 
     /// Set the data to be checked and removed potential text field
+    #[must_use]
     pub fn with_data(mut self, data: Data) -> Self {
         self.data = Some(data);
         self.text = None;
@@ -376,6 +383,7 @@ impl CheckRequest {
     }
 
     /// Set the language of the text / data
+    #[must_use]
     pub fn with_language(mut self, language: String) -> Self {
         self.language = language;
         self
@@ -387,6 +395,7 @@ impl CheckRequest {
     ///
     /// Panics if both self.text and self.data are None.
     /// Panics if any data annotation does not contain text or markup.
+    #[must_use]
     pub fn get_text(&self) -> String {
         if let Some(ref text) = self.text {
             text.clone()
@@ -658,6 +667,7 @@ pub struct CheckResponseWithContext {
 
 impl CheckResponseWithContext {
     /// Bind a check response with its original text.
+    #[must_use]
     pub fn new(text: String, response: CheckResponse) -> Self {
         let text_length = text.chars().count();
         Self {
@@ -678,6 +688,7 @@ impl CheckResponseWithContext {
     }
 
     /// Return an iterator over matches and correspondig line number and line offset.
+    #[must_use]
     pub fn iter_match_positions(&self) -> MatchPositions<'_, std::slice::Iter<'_, Match>> {
         self.into()
     }
@@ -686,6 +697,7 @@ impl CheckResponseWithContext {
     /// adjusting the matches' offsets.
     ///
     /// This is especially useful when a text was split in multiple requests.
+    #[must_use]
     pub fn append(mut self, mut other: Self) -> Self {
         let offset = self.text_length;
         for m in other.iter_matches_mut() {

--- a/src/lib/server.rs
+++ b/src/lib/server.rs
@@ -270,6 +270,7 @@ impl ServerCli {
     /// Create a new [`ServerCli`] instance from environ variables,
     /// but defaults to [`ServerCli::default`()] if expected environ
     /// variables are not set.
+    #[must_use]
     pub fn from_env_or_default() -> Self {
         ServerCli::from_env().unwrap_or_default()
     }


### PR DESCRIPTION
This adds `#[must_use]` flag to most structure to please clippy pedantic.