### PR TITLE
feat(cli/lib): new error when docker is not found

### DIFF
--- a/.github/workflows/rustlib.yml
+++ b/.github/workflows/rustlib.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [latest, '5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9', '6.0']
+        tag: [latest, '5.5', '5.6', '5.7', '5.8', '5.9', '6.0']
     runs-on: ubuntu-latest
     env:
       LANGUAGETOOL_HOSTNAME: http://localhost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added message when reading from STDIN. [#25](https://github.com/jeertmans/languagetool-rust/pull/25), [#26](https://github.com/jeertmans/languagetool-rust/pull/26)
 - Added (regex) validator for language code. [#27](https://github.com/jeertmans/languagetool-rust/pull/27)
 - Added cli requirements for `username`/`api_key` pair. [#16](https://github.com/jeertmans/languagetool-rust/pull/16), [#30](https://github.com/jeertmans/languagetool-rust/pull/30)
+- Added a `CommandNotFound` error variant for when docker is not found. [#52](https://github.com/jeertmans/languagetool-rust/pull/52)
 
 ### Changed
 

--- a/src/lib/docker.rs
+++ b/src/lib/docker.rs
@@ -1,7 +1,7 @@
 //! Structures and methods to easily manipulate Docker images, especially for `LanguageTool`
 //! applications.
 
-use crate::error::{exit_status_error, Result};
+use crate::error::{exit_status_error, Error, Result};
 #[cfg(feature = "cli")]
 use clap::Parser;
 use std::process::{Command, Output, Stdio};
@@ -77,7 +77,8 @@ impl Docker {
             .args(["pull", &self.name])
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
-            .output()?;
+            .output()
+            .map_err(|_| Error::CommandNotFound(self.bin.to_string()))?;
 
         exit_status_error(&output.status)?;
 
@@ -99,7 +100,8 @@ impl Docker {
             ])
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
-            .output()?;
+            .output()
+            .map_err(|_| Error::CommandNotFound(self.bin.to_string()))?;
 
         exit_status_error(&output.status)?;
 
@@ -117,7 +119,8 @@ impl Docker {
                 "-q",
             ])
             .stderr(Stdio::inherit())
-            .output()?;
+            .output()
+            .map_err(|_| Error::CommandNotFound(self.bin.to_string()))?;
 
         exit_status_error(&output.status)?;
 

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -56,6 +56,10 @@ pub enum Error {
     #[error(transparent)]
     /// Error from reading environ variable (see [std::env::VarError]).
     VarError(#[from] std::env::VarError),
+
+    #[error("command not found: {0}")]
+    /// Error when a process command was not found.
+    CommandNotFound(String),
 }
 
 /// Result type alias with error type defined above (see [Error]).


### PR DESCRIPTION
This adds a new error variant to indicate when docker command is not found, which was previously a dummy IO error that did not help