### PR TITLE
feat(cli): also split text for `--text` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added cli requirements for `username`/`api_key` pair. [#16](https://github.com/jeertmans/languagetool-rust/pull/16), [#30](https://github.com/jeertmans/languagetool-rust/pull/30)
 - Added a `CommandNotFound` error variant for when docker is not found. [#52](https://github.com/jeertmans/languagetool-rust/pull/52)
 - Added a `split_len` function. [#18](https://github.com/jeertmans/languagetool-rust/pull/18)
-- Automatically split long text into multiple fragments. [#58](https://github.com/jeertmans/languagetool-rust/pull/58)
+- Automatically split long text into multiple fragments. [#58](https://github.com/jeertmans/languagetool-rust/pull/58), [#60](https://github.com/jeertmans/languagetool-rust/pull/60)
 - Add `try_` variants for panicking functions. [#59](https://github.com/jeertmans/languagetool-rust/pull/59)
 
 ### Changed

--- a/src/lib/cli.rs
+++ b/src/lib/cli.rs
@@ -123,7 +123,13 @@ impl Cli {
                         read_from_stdin(&mut stdout, &mut text)?;
                         request = request.with_text(text);
                     }
-                    let mut response = server_client.check(&request).await?;
+
+                    let mut response = if request.text.is_some() {
+                        let requests = request.split(cmd.max_length, cmd.split_pattern.as_str());
+                        server_client.check_multiple_and_join(requests).await?
+                    } else {
+                        server_client.check(&request).await?
+                    };
 
                     if request.text.is_some() && !cmd.raw {
                         let text = request.text.unwrap();


### PR DESCRIPTION
This implements the missing splitting for `--text` option.