### PR TITLE
feat(cli/lib): fix words requests and add environ. variables for login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unrealease](https://github.com/jeertmans/languagetool-rust/compare/v2.0.0...HEAD)
+
+### Added
+
+- Added environment variables for login arguments. [#64](https://github.com/jeertmans/languagetool-rust/pull/64)
+
+### Fixed
+
+- Fixed words requests. [#64](https://github.com/jeertmans/languagetool-rust/pull/64)
+
+
 ## [2.0.0](https://github.com/jeertmans/languagetool-rust/compare/v1.3.0...v2.0.0) 2023-02-07
 
 ### Chore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed words requests. [#64](https://github.com/jeertmans/languagetool-rust/pull/64)
 
-
 ## [2.0.0](https://github.com/jeertmans/languagetool-rust/compare/v1.3.0...v2.0.0) 2023-02-07
 
 ### Chore

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -414,12 +414,18 @@ pub struct CheckRequest {
     pub language: String,
     /// Set to get Premium API access: Your username/email as used to log in at
     /// languagetool.org.
-    #[cfg_attr(feature = "cli", clap(short = 'u', long, requires = "api_key"))]
+    #[cfg_attr(
+        feature = "cli",
+        clap(short = 'u', long, requires = "api_key", env = "LANGUAGETOOL_USERNAME")
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
     /// Set to get Premium API access: [your API
     /// key](https://languagetool.org/editor/settings/api).
-    #[cfg_attr(feature = "cli", clap(short = 'k', long, requires = "username"))]
+    #[cfg_attr(
+        feature = "cli",
+        clap(short = 'k', long, requires = "username", env = "LANGUAGETOOL_API_KEY")
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
     /// Comma-separated list of dictionaries to include words from; uses special

--- a/src/lib/cli.rs
+++ b/src/lib/cli.rs
@@ -190,7 +190,7 @@ impl Cli {
                         serde_json::to_string_pretty(&words_response)?
                     },
                     None => {
-                        let words_response = server_client.words(&cmd.request).await?;
+                        let words_response = server_client.words(&cmd.request.into()).await?;
                         serde_json::to_string_pretty(&words_response)?
                     },
                 };

--- a/src/lib/words.rs
+++ b/src/lib/words.rs
@@ -33,10 +33,16 @@ pub fn parse_word(v: &str) -> Result<String> {
 #[non_exhaustive]
 pub struct LoginArgs {
     /// Your username as used to log in at languagetool.org.
-    #[cfg_attr(feature = "cli", clap(short = 'u', long, required = true))]
+    #[cfg_attr(
+        feature = "cli",
+        clap(short = 'u', long, required = true, env = "LANGUAGETOOL_USERNAME")
+    )]
     pub username: String,
-    /// [Your API key](https://languagetool.org/editor/settings/api)
-    #[cfg_attr(feature = "cli", clap(short = 'k', long, required = true))]
+    /// [Your API key](https://languagetool.org/editor/settings/api).
+    #[cfg_attr(
+        feature = "cli",
+        clap(short = 'k', long, required = true, env = "LANGUAGETOOL_API_KEY")
+    )]
     pub api_key: String,
 }
 
@@ -53,11 +59,12 @@ pub struct WordsRequest {
     /// Maximum number of words to return.
     #[cfg_attr(feature = "cli", clap(long, default_value = "10"))]
     pub limit: isize,
-    /// Login arguments
+    /// Login arguments.
     #[cfg_attr(feature = "cli", clap(flatten))]
-    pub login: LoginArgs,
+    #[serde(flatten)]
+    pub login: Option<LoginArgs>,
     /// Comma-separated list of dictionaries to include words from; uses special
-    /// default dictionary if this is unset
+    /// default dictionary if this is unset.
     #[cfg_attr(feature = "cli", clap(long))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dicts: Option<Vec<String>>,
@@ -77,12 +84,13 @@ pub struct WordsAddRequest {
     /// languages.
     #[cfg_attr(feature = "cli", clap(required = true, value_parser = parse_word))]
     pub word: String,
-    /// Login arguments
+    /// Login arguments.
     #[cfg_attr(feature = "cli", clap(flatten))]
+    #[serde(flatten)]
     pub login: LoginArgs,
     /// Name of the dictionary to add the word to; non-existent dictionaries are
     /// created after calling this; if unset, adds to special default
-    /// dictionary
+    /// dictionary.
     #[cfg_attr(feature = "cli", clap(long))]
     #[serde(skip_serializing_if = "Option::is_none")]
     dict: Option<String>,
@@ -100,6 +108,7 @@ pub struct WordsDeleteRequest {
     pub word: String,
     /// Login arguments.
     #[cfg_attr(feature = "cli", clap(flatten))]
+    #[serde(flatten)]
     pub login: LoginArgs,
     /// Name of the dictionary to add the word to; non-existent dictionaries are
     /// created after calling this; if unset, adds to special default
@@ -122,7 +131,8 @@ pub enum WordsSubcommand {
 /// Retrieve some user's words list.
 #[cfg(feature = "cli")]
 #[derive(Debug, Parser)]
-#[clap(subcommand_negates_reqs(true))]
+#[clap(args_conflicts_with_subcommands = true)]
+#[clap(subcommand_negates_reqs = true)]
 pub struct WordsCommand {
     /// Actual GET request.
     #[command(flatten)]
@@ -136,7 +146,7 @@ pub struct WordsCommand {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct WordsResponse {
-    /// List of words
+    /// List of words.
     words: Vec<String>,
 }
 
@@ -144,7 +154,7 @@ pub struct WordsResponse {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct WordsAddResponse {
-    /// `true` if word was correctly added
+    /// `true` if word was correctly added.
     added: bool,
 }
 
@@ -152,6 +162,6 @@ pub struct WordsAddResponse {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct WordsDeleteResponse {
-    /// `true` if word was correctly removed
+    /// `true` if word was correctly removed.
     deleted: bool,
 }

--- a/src/lib/words.rs
+++ b/src/lib/words.rs
@@ -62,12 +62,50 @@ pub struct WordsRequest {
     /// Login arguments.
     #[cfg_attr(feature = "cli", clap(flatten))]
     #[serde(flatten)]
+    pub login: LoginArgs,
+    /// Comma-separated list of dictionaries to include words from; uses special
+    /// default dictionary if this is unset.
+    #[cfg_attr(feature = "cli", clap(long))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dicts: Option<Vec<String>>,
+}
+
+/// Copy of [`WordsRequest`], but used to CLI only.
+///
+/// This is a temporary solution, until [#3165](https://github.com/clap-rs/clap/issues/3165) is
+/// closed.
+#[cfg(feature = "cli")]
+#[derive(Args, Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct WordsRequestArgs {
+    /// Offset of where to start in the list of words.
+    #[cfg_attr(feature = "cli", clap(long, default_value = "0"))]
+    offset: isize,
+    /// Maximum number of words to return.
+    #[cfg_attr(feature = "cli", clap(long, default_value = "10"))]
+    pub limit: isize,
+    /// Login arguments.
+    #[cfg_attr(feature = "cli", clap(flatten))]
+    #[serde(flatten)]
     pub login: Option<LoginArgs>,
     /// Comma-separated list of dictionaries to include words from; uses special
     /// default dictionary if this is unset.
     #[cfg_attr(feature = "cli", clap(long))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dicts: Option<Vec<String>>,
+}
+
+#[cfg(feature = "cli")]
+impl From<WordsRequestArgs> for WordsRequest {
+    #[inline]
+    fn from(args: WordsRequestArgs) -> Self {
+        Self {
+            offset: args.offset,
+            limit: args.limit,
+            login: args.login.unwrap(),
+            dicts: args.dicts,
+        }
+    }
 }
 
 /// LanguageTool POST words add request.
@@ -93,7 +131,7 @@ pub struct WordsAddRequest {
     /// dictionary.
     #[cfg_attr(feature = "cli", clap(long))]
     #[serde(skip_serializing_if = "Option::is_none")]
-    dict: Option<String>,
+    pub dict: Option<String>,
 }
 
 /// LanguageTool POST words delete request.
@@ -136,7 +174,7 @@ pub enum WordsSubcommand {
 pub struct WordsCommand {
     /// Actual GET request.
     #[command(flatten)]
-    pub request: WordsRequest,
+    pub request: WordsRequestArgs,
     /// Optional subcommand.
     #[command(subcommand)]
     pub subcommand: Option<WordsSubcommand>,
@@ -147,7 +185,7 @@ pub struct WordsCommand {
 #[non_exhaustive]
 pub struct WordsResponse {
     /// List of words.
-    words: Vec<String>,
+    pub words: Vec<String>,
 }
 
 /// LanguageTool POST word add response.
@@ -155,7 +193,7 @@ pub struct WordsResponse {
 #[non_exhaustive]
 pub struct WordsAddResponse {
     /// `true` if word was correctly added.
-    added: bool,
+    pub added: bool,
 }
 
 /// LanguageTool POST word delete response.
@@ -163,5 +201,5 @@ pub struct WordsAddResponse {
 #[non_exhaustive]
 pub struct WordsDeleteResponse {
     /// `true` if word was correctly removed.
-    deleted: bool,
+    pub deleted: bool,
 }


### PR DESCRIPTION
This closes #62 by adding environment variables for API key. It also fixes words requests, both on the library (missing struct flattening) and on the CLI side (Option<T>). The latter solution was found in discussion: https://github.com/clap-rs/clap/discussions/4427.