### PR TITLE
Fix json case for `DataAnnotation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unrealeased](https://github.com/jeertmans/languagetool-rust/compare/v2.1.3...HEAD)
+
+### Fixed
+
+- Fixed serializing of `interpretAs` in `data`. [#103](https://github.com/jeertmans/languagetool-rust/pull/103)
+
 ## [2.1.3](https://github.com/jeertmans/languagetool-rust/compare/v2.1.2...v2.1.3)
 
 ### Chore

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -123,6 +123,7 @@ where
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
+#[serde(rename_all = "camelCase")]
 /// A portion of text to be checked.
 pub struct DataAnnotation {
     /// If set, the markup will be interpreted as this.


### PR DESCRIPTION
`interpret_as` did not work for me with the default local languagetool-server from the website.

This changes the json field to `interpretAs`, which matches the example in the API documentation.