### PR TITLE
refactor: consolidate `reqwest` errors

### DIFF
--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -369,38 +369,35 @@ impl ServerClient {
 
     /// Send a check request to the server and await for the response.
     pub async fn check(&self, request: &Request<'_>) -> Result<Response> {
-        match self
+        let resp = self
             .client
             .post(format!("{0}/check", self.api))
             .query(request)
             .send()
             .await
-        {
-            Ok(resp) => {
-                match resp.error_for_status_ref() {
-                    Ok(_) => {
-                        resp.json::<Response>()
-                            .await
-                            .map_err(Error::ResponseDecode)
-                            .map(|mut resp| {
-                                if self.max_suggestions > 0 {
-                                    let max = self.max_suggestions as usize;
-                                    resp.matches.iter_mut().for_each(|m| {
-                                        let len = m.replacements.len();
-                                        if max < len {
-                                            m.replacements[max] =
-                                                format!("... ({} not shown)", len - max).into();
-                                            m.replacements.truncate(max + 1);
-                                        }
-                                    });
+            .map_err(Error::Reqwest)?;
+
+        match resp.error_for_status_ref() {
+            Ok(_) => {
+                resp.json::<Response>()
+                    .await
+                    .map_err(Into::into)
+                    .map(|mut resp| {
+                        if self.max_suggestions > 0 {
+                            let max = self.max_suggestions as usize;
+                            resp.matches.iter_mut().for_each(|m| {
+                                let len = m.replacements.len();
+                                if max < len {
+                                    m.replacements[max] =
+                                        format!("... ({} not shown)", len - max).into();
+                                    m.replacements.truncate(max + 1);
                                 }
-                                resp
-                            })
-                    },
-                    Err(_) => Err(Error::InvalidRequest(resp.text().await?)),
-                }
+                            });
+                        }
+                        resp
+                    })
             },
-            Err(e) => Err(Error::RequestEncode(e)),
+            Err(_) => Err(Error::InvalidRequest(resp.text().await?)),
         }
     }
 
@@ -467,69 +464,52 @@ impl ServerClient {
 
     /// Send a languages request to the server and await for the response.
     pub async fn languages(&self) -> Result<languages::Response> {
-        match self
+        let resp = self
             .client
             .get(format!("{}/languages", self.api))
             .send()
             .await
-        {
-            Ok(resp) => {
-                match resp.error_for_status_ref() {
-                    Ok(_) => {
-                        resp.json::<languages::Response>()
-                            .await
-                            .map_err(Error::ResponseDecode)
-                    },
-                    Err(_) => Err(Error::InvalidRequest(resp.text().await?)),
-                }
-            },
-            Err(e) => Err(Error::RequestEncode(e)),
+            .map_err(Error::Reqwest)?;
+
+        match resp.error_for_status_ref() {
+            Ok(_) => resp.json::<languages::Response>().await.map_err(Into::into),
+            Err(_) => Err(Error::InvalidRequest(resp.text().await?)),
         }
     }
 
     /// Send a words request to the server and await for the response.
     pub async fn words(&self, request: &words::Request) -> Result<words::Response> {
-        match self
+        let resp = self
             .client
             .get(format!("{}/words", self.api))
             .query(request)
             .send()
             .await
-        {
-            Ok(resp) => {
-                match resp.error_for_status_ref() {
-                    Ok(_) => {
-                        resp.json::<words::Response>()
-                            .await
-                            .map_err(Error::ResponseDecode)
-                    },
-                    Err(_) => Err(Error::InvalidRequest(resp.text().await?)),
-                }
-            },
-            Err(e) => Err(Error::RequestEncode(e)),
+            .map_err(Error::Reqwest)?;
+
+        match resp.error_for_status_ref() {
+            Ok(_) => resp.json::<words::Response>().await.map_err(Error::Reqwest),
+            Err(_) => Err(Error::InvalidRequest(resp.text().await?)),
         }
     }
 
     /// Send a words/add request to the server and await for the response.
     pub async fn words_add(&self, request: &words::add::Request) -> Result<words::add::Response> {
-        match self
+        let resp = self
             .client
             .post(format!("{}/words/add", self.api))
             .query(request)
             .send()
             .await
-        {
-            Ok(resp) => {
-                match resp.error_for_status_ref() {
-                    Ok(_) => {
-                        resp.json::<words::add::Response>()
-                            .await
-                            .map_err(Error::ResponseDecode)
-                    },
-                    Err(_) => Err(Error::InvalidRequest(resp.text().await?)),
-                }
+            .map_err(Error::Reqwest)?;
+
+        match resp.error_for_status_ref() {
+            Ok(_) => {
+                resp.json::<words::add::Response>()
+                    .await
+                    .map_err(Error::Reqwest)
             },
-            Err(e) => Err(Error::RequestEncode(e)),
+            Err(_) => Err(Error::InvalidRequest(resp.text().await?)),
         }
     }
 
@@ -538,24 +518,21 @@ impl ServerClient {
         &self,
         request: &words::delete::Request,
     ) -> Result<words::delete::Response> {
-        match self
+        let resp = self
             .client
             .post(format!("{}/words/delete", self.api))
             .query(request)
             .send()
             .await
-        {
-            Ok(resp) => {
-                match resp.error_for_status_ref() {
-                    Ok(_) => {
-                        resp.json::<words::delete::Response>()
-                            .await
-                            .map_err(Error::ResponseDecode)
-                    },
-                    Err(_) => Err(Error::InvalidRequest(resp.text().await?)),
-                }
+            .map_err(Error::Reqwest)?;
+
+        match resp.error_for_status_ref() {
+            Ok(_) => {
+                resp.json::<words::delete::Response>()
+                    .await
+                    .map_err(Error::Reqwest)
             },
-            Err(e) => Err(Error::RequestEncode(e)),
+            Err(_) => Err(Error::InvalidRequest(resp.text().await?)),
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -147,12 +147,9 @@ mod tests {
     }
 
     #[ignore]
-    #[ignore]
-    #[test]
-    fn test_error_reqwest() {
-        let result = std::fs::read_to_string(""); // TODO
-        assert!(result.is_err());
-
+    #[tokio::test]
+    async fn test_error_reqwest() {
+        let result = reqwest::get("").await;
         let error: Error = result.unwrap_err().into();
 
         assert!(matches!(error, Error::Reqwest(_)));

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,17 +52,9 @@ pub enum Error {
     #[error("could not parse {0:?} in a Docker action")]
     ParseAction(String),
 
-    /// Error from request encoding.
-    #[error("request could not be properly encoded: {0}")]
-    RequestEncode(reqwest::Error),
-
     /// Any other error from requests (see [`reqwest::Error`]).
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
-
-    /// Error from request decoding.
-    #[error("response could not be properly decoded: {0}")]
-    ResponseDecode(reqwest::Error),
 
     /// Error from reading environ variable (see [`std::env::VarError`]).
     #[error(transparent)]
@@ -155,27 +147,6 @@ mod tests {
     }
 
     #[ignore]
-    #[test]
-    fn test_error_request_encode() {
-        let result = std::fs::read_to_string(""); // TODO
-        assert!(result.is_err());
-
-        let error: Error = result.unwrap_err().into();
-
-        assert!(matches!(error, Error::RequestEncode(_)));
-    }
-
-    #[ignore]
-    #[test]
-    fn test_error_response_decode() {
-        let result = std::fs::read_to_string(""); // TODO
-        assert!(result.is_err());
-
-        let error: Error = result.unwrap_err().into();
-
-        assert!(matches!(error, Error::ResponseDecode(_)));
-    }
-
     #[ignore]
     #[test]
     fn test_error_reqwest() {


### PR DESCRIPTION
This removes `Error::RequestEncode` and `Error::RequestDecode`. Also did some minor refactoring to remove excessive indentation, and implemented the test for `Error::Reqwest` (though I think maybe that's not necessary - feels like testing implementation details).

Note: I believe I accidentally made this branch from the main repo and not my fork - my bad. If that's an issue I can make a new PR.

