### PR TITLE
ci: include newer versions of `languagetool` in tests

### DIFF
--- a/.github/workflows/rustlib.yml
+++ b/.github/workflows/rustlib.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [latest, '5.5', '5.6', '5.7', '5.8', '5.9', '6.0', '6.1']
+        tag: [latest, '5.5', '5.6', '5.7', '5.8', '5.9', '6.0', '6.1', '6.2', '6.3', '6.4', '6.5']
     runs-on: ubuntu-latest
     services:
       languagetool:

--- a/.github/workflows/rustlib.yml
+++ b/.github/workflows/rustlib.yml
@@ -51,4 +51,4 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-    - run: cargo nextest run --all-features
+    - run: cargo nextest run --all-features --no-capture

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -594,19 +594,23 @@ impl ServerClient {
 #[cfg(test)]
 mod tests {
     use super::ServerClient;
-    use crate::api::check::Request;
+    use crate::{api::check::Request, error};
+
+    fn dbg_err(e: &error::Error) {
+        eprintln!("Error: {e:?}")
+    }
 
     #[tokio::test]
     async fn test_server_ping() {
         let client = ServerClient::from_env_or_default();
-        assert!(client.ping().await.is_ok());
+        assert!(client.ping().await.inspect_err(dbg_err).is_ok());
     }
 
     #[tokio::test]
     async fn test_server_check_text() {
         let client = ServerClient::from_env_or_default();
         let req = Request::default().with_text("je suis une poupee");
-        assert!(client.check(&req).await.is_ok());
+        assert!(client.check(&req).await.inspect_err(dbg_err).is_ok());
     }
 
     #[tokio::test]
@@ -615,12 +619,12 @@ mod tests {
         let req = Request::default()
             .with_data_str("{\"annotation\":[{\"text\": \"je suis une poupee\"}]}")
             .unwrap();
-        assert!(client.check(&req).await.is_ok());
+        assert!(client.check(&req).await.inspect_err(dbg_err).is_ok());
     }
 
     #[tokio::test]
     async fn test_server_languages() {
         let client = ServerClient::from_env_or_default();
-        assert!(client.languages().await.is_ok());
+        assert!(client.languages().await.inspect_err(dbg_err).is_ok());
     }
 }


### PR DESCRIPTION
Just adding in the newer versions as requested. Hopefully we can also use this  branch for figuring out why the tests for the latest version was/is failing