### PR TITLE
chore: add `docker-compose.yml` file to simplify running a local API for tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  languagetool:
+    image: erikvl87/languagetool:latest
+    container_name: languagetool
+    pull_policy: always
+    ports:
+    - 8010:8010
+    environment:
+      langtool_maxTextLength: 1500
+      Java_Xmx: 2g


### PR DESCRIPTION
Finishing touches for #117.

This one adds a `docker-compose.yml` to easily setup a locally hosted version of LanguageTool for running the test suite against. The environment variables are important as the max length is used assumed in the tests, and the Java memory increase was required for me to avoid the service crashing when running the full test suite.