### PR TITLE
chore: Release languagetool-rust version 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 
-## [Unreleased](https://github.com/jeertmans/languagetool-rust/compare/v2.1.5...HEAD)
+## [Unreleased](https://github.com/jeertmans/languagetool-rust/compare/v3.0.0...HEAD)
+
+## [3.0.0](https://github.com/jeertmans/languagetool-rust/compare/v2.1.5...3.0.0) 2025-09-17
 
 > [!IMPORTANT]
 > This new major release includes many breaking changes, all made in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "languagetool-rust"
-version = "3.0.0-rc.1"
+version = "3.0.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ name = "languagetool-rust"
 readme = "README.md"
 repository = "https://github.com/jeertmans/languagetool-rust"
 rust-version = "1.82.0"
-version = "3.0.0-rc.1"
+version = "3.0.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
No bugs or issues have been reported since the pre-release was published, so I'm assuming we can move on and finally publish v3!