### PR TITLE
fix: split typst list items into separate sentences

### DIFF
--- a/src/parsers/typst.rs
+++ b/src/parsers/typst.rs
@@ -72,6 +72,13 @@ pub fn parse_typst(file_content: impl AsRef<str>) -> Data<'static> {
                     full_text,
                     interpreted_as,
                 ));
+
+                // Separate list entries so LanguageTool does not merge
+                // consecutive items into a single sentence.
+                if matches!(kind, SyntaxKind::ListItem | SyntaxKind::EnumItem) {
+                    annotations.push(DataAnnotation::new_text("\n"));
+                }
+
                 continue;
             },
             _ => {},


### PR DESCRIPTION
Fixes #205

Typst list and enum items were emitted back-to-back in the parsed text, so LanguageTool treated the next item as a continuation of the previous sentence.

This inserts a newline annotation after each `ListItem`/`EnumItem` so every list entry starts as its own sentence.

Greetings, saschabuehrle
