### PR TITLE
fix(cli): bring back --more-context flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/jeertmans/languagetool-rust/compare/v3.0.1...HEAD)
 
+### Fixed
+
+- Bring back --more-context flag
+
 ## [3.0.1](https://github.com/jeertmans/languagetool-rust/compare/v3.0.0...3.0.1) 2025-12-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bring back --more-context flag
+- Bring back --more-context flag ([@Dosx001](https://github.com/Dosx001)). [#210](https://github.com/jeertmans/languagetool-rust/pull/210)
 
 ## [3.0.1](https://github.com/jeertmans/languagetool-rust/compare/v3.0.0...3.0.1) 2025-12-31
 

--- a/src/api/check/requests.rs
+++ b/src/api/check/requests.rs
@@ -242,6 +242,10 @@ pub struct Request<'source> {
     /// you might only find useful when checking formal text.
     #[serde(skip_serializing_if = "Level::is_default")]
     pub level: Level,
+    /// If present, more context (i.e., line number and line offset) will be
+    /// added to the response.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub more_context: bool,
 }
 
 impl<'source> Request<'source> {

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -127,13 +127,21 @@ impl ExecuteSubcommand for Command {
                     return Ok(());
                 }
                 // Split text into multiple parts to be checked
+                let more_context = request.more_context;
                 let requests = request.split(self.max_length, self.split_pattern.as_str());
 
                 if self.raw {
                     // RAW JSON output does not carry 'context' information
-                    let response = server_client
-                        .check_multiple_and_join_without_context(requests)
-                        .await?;
+                    let response = if more_context {
+                        server_client
+                            .check_multiple_and_join(requests)
+                            .await?
+                            .into()
+                    } else {
+                        server_client
+                            .check_multiple_and_join_without_context(requests)
+                            .await?
+                    };
                     writeln!(&mut stdout, "{}", serde_json::to_string_pretty(&response)?)?;
                 } else {
                     let response_with_context =
@@ -222,6 +230,11 @@ impl ExecuteSubcommand for Command {
             };
 
             if self.raw {
+                let response = if request.more_context {
+                    check::ResponseWithContext::new(Cow::from(text), response).into()
+                } else {
+                    response
+                };
                 writeln!(&mut stdout, "{}", serde_json::to_string_pretty(&response)?)?;
             } else {
                 writeln!(
@@ -352,6 +365,10 @@ pub struct CliRequest {
         clap(long, default_value = "default", ignore_case = true, value_enum)
     )]
     pub level: Level,
+    /// If present, more context (i.e., line number and line offset) will be
+    /// added to the response.
+    #[clap(short = 'm', long)]
+    pub more_context: bool,
 }
 
 impl From<CliRequest> for Request<'_> {
@@ -371,6 +388,7 @@ impl From<CliRequest> for Request<'_> {
             disabled_categories: val.disabled_categories,
             enabled_only: val.enabled_only,
             level: val.level,
+            more_context: val.more_context,
         }
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -496,6 +496,33 @@ fn test_check_with_unexisting_level() {
 }
 
 #[test]
+fn test_check_with_more_context() {
+    let assert = get_cmd()
+        .arg("check")
+        .arg("--more-context")
+        .arg("--raw")
+        .arg("--text")
+        .arg("\"some text that is given as text\"")
+        .assert();
+    assert.success().stdout(contains("line_number"));
+}
+
+#[test]
+fn test_check_with_more_context_and_file() {
+    use std::io::Write;
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    writeln!(file, "Some text with a error inside.").unwrap();
+
+    let assert = get_cmd()
+        .arg("check")
+        .arg("--more-context")
+        .arg("--raw")
+        .arg(file.path().to_str().unwrap())
+        .assert();
+    assert.success().stdout(contains("line_number"));
+}
+
+#[test]
 fn test_languages() {
     let assert = get_cmd().arg("languages").assert();
     assert.success();


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR
with the issue. #999 stands for the issue number you are fixing -->

The `--more-context`/`-m` flag was removed during 3.0.0 release. I brought it back.

# Fixes Issue

This flag is needed for ltrs to work with neovim. The `--more-context` flag provides the line number.
https://github.com/nvimtools/none-ls.nvim/blob/main/lua/null-ls/builtins/diagnostics/ltrs.lua#L52

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

# Description

<!-- Describe all the proposed changes in your PR -->

## Check List (Check all the applicable boxes)

- [x] I understand that my contributions needs to pass the checks.
- [ ] If I created new functions / methods, I documented them and add type hints.
- [ ] If I modified already existing code, I updated the documentation accordingly.
- [ ] The title of my pull request is a short description of the requested changes.

# Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
